### PR TITLE
Copy confd templates from /var/www/drupal

### DIFF
--- a/drupal/rootfs/etc/cont-init.d/001-copy-confd-templates.sh
+++ b/drupal/rootfs/etc/cont-init.d/001-copy-confd-templates.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bash
+
+# Intended for confd definitions and templates to be provided via 
+# the Drupal codebase.
+if [ -d /var/www/drupal/rootfs/etc/confd ]; then
+	cp -r /var/www/drupal/rootfs/etc/confd/* /etc/confd/;
+fi


### PR DESCRIPTION
# Overview

This allows confd templates to be defined and maintained as part of drupal development in idc-isle-dc.  Any confd config file or template under `codebase/rootfs/etc/confd/` (more accurately, present to the drupal container as `/var/www/drupal/rootfs/etc/confd/`) will be copied to the corresponding place under `/etc/confd` before rendering templates. This allows developer control over confd templates for Drupal without having to build new buildkit images every time.

# To Test
1. Build the images in this PR via ./gradlew build
2. Take the as-built tag (e.g. something like `upstream-20200824-f8d1e8e-12-gd582c0a`), fo into `idc-isle-dc` development branch and use that value for `TAG` in `.env`.  Rebuild `docker-compose.yml` (or `make reset`), and start up the environment.  It should start without error (i.e. this change causes no harm if there is no `rootfs` directory.
3.  Now stop the stack, create a file such as `codebase/rootfs/etc/confd/foo.bar`.  Start up the stack.  Hop into the drupal container interactively and verify that your file is now under `/etc/confd`.

A subsequent PR to idc-isle-dc will leverage this capability to add confd templates for `settings.php`.   