### PR TITLE
Fix Drupal initialization process with respect to errors

### DIFF
--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/with-contenv bash
 set -x
 
+if [ -z "${DRUPAL_IGNORE_STARTUP_ERRORS}" ] || [ "${DRUPAL_IGNORE_STARTUP_ERRORS}" != "true" ]; then
+  set -e
+fi
+
 echo "Executing Islandora setup with the following environment:"
 env # cannot pipe through sort, because some vars are multi-line
 echo

--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -162,7 +162,8 @@ function main {
   # Perform runtime configuration if it is not a dev env.
   if [ -n "${DRUPAL_INSTANCE}" ] && [ "${DRUPAL_INSTANCE}" != "dev" ] ;
   then
-    perform_runtime_config "${site_url}"
+    # TODO:  This fails and needs to be fixed or factored out
+    perform_runtime_config "${site_url}" || printf "\n\nWARNING: runtime config failed, ignoring\n\n"
   fi
 
   # Disable maintenance mode

--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -122,15 +122,16 @@ function main {
   # Records whether or not we are starting from an empty database; this is a proxy for determining if Drupal is
   # already installed or not.  If installed_custom returns 0, then Drupal is already installed.  If >0, Drupal is
   # not installed.
-  $(installed_local)
-  local is_installed=$?
+
+  local db_count=0
+  $(installed_local) || db_count=$?
 
   # Install Composer modules if necessary.
   COMPOSER_MEMORY_LIMIT=-1 composer install
 
-  if [ ${is_installed} -lt 1 ] ; then
-    echo "Drupal is not installed, no pre-existing state found."
-    exit 0
+  if [ -z "${db_count}" ] || [ "${db_count}" -lt 1 ] ; then
+    printf "\n\nERROR: Drupal is not installed, no pre-existing state found\n\n"
+    exit 1
   fi
 
   # Enter maintenance mode, run any database hooks from updated modules,


### PR DESCRIPTION
Previously, any steps of the Drupal container initialization in `etc/cont-init.d/99-custom-detup.sh` were non-fatal.  Notably, part of  a non-dev Drupal instance's startup sequence involves [importing configuration](https://github.com/jhu-idc/idc-isle-buildkit/blob/main/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh#L154), which would fail.  In a production environment, this should be fatal (as otherwise, Drupal would start with a possibly indeterminate config that differs from the developer's intentions).  

This PR changes the default behaviour of the initialization script so that the Drupal container will terminate with a non-zero error code if any step of initialization fails.

the environment variable `DRUPAL_IGNORE_STARTUP_ERRORS` can be set to `true` in order to revert to the old behaviour that allows a mis-configured Drupal to at least run for the sake of forensics/debugging.  

Additionally, the following changes were also made:
* The [logic that detected the presence/absence of mysql tables](https://github.com/jhu-idc/idc-isle-buildkit/blob/main/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh#L131) was wrong, and was previously unable to detect when mysql was connected, but there were zero Drupal tables.  This has been fixed
* [perform_runtime_config](https://github.com/jhu-idc/idc-isle-buildkit/blob/main/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh#L160) fails for static/cloud configurations, and needs to be looked at in a separate issue.  This PR temporarily allows this failure to happen without terminating Drupal, just so that fixing it doesn't become a blocker

# To test

* build all images `./gradlew build`
* copy the resulting tag into the TAG variable in `idc-isle-dc/.env`
* do `make up`, it should start fine.  then `docker-compose down -v`
* do `make static-docker-compose.yml`, and `make up`.  It should ***fail***.  This is because of a bug who's fix is pending
* edit `docker-compose.yml` and add `DRUPAL_IGNORE_STARTUP_ERRORS: true` to the `drupal` container's environment.  do `make up` and verify that Drupal starts successfully.

It's also possible to verify the mysql fix via
* in `idc-isle-dc` with the updated `TAG`, change `SNAPSHOT_TAG` in `.env` to be `empty` (or do `make snapshot-empty`).   Do the normal `make docker-compose.yml`, and try to start.  It should fail.  Look at the Dupal logs and verify that it prints out the expected message "Drupal is not installed, no pre-existing state found"

Resolves #8 