### PR TITLE
Fix runtime configuration on startup in cloud

### DIFF
--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -161,8 +161,7 @@ function main {
   # Perform runtime configuration if it is not a dev env.
   if [ -n "${DRUPAL_INSTANCE}" ] && [ "${DRUPAL_INSTANCE}" != "dev" ] ;
   then
-    # TODO:  This fails and needs to be fixed or factored out
-    perform_runtime_config "${site}" || printf "\n\nWARNING: runtime config failed, ignoring\n\n"
+    perform_runtime_config "${site}"
   fi
 
   # Disable maintenance mode

--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -163,7 +163,7 @@ function main {
   if [ -n "${DRUPAL_INSTANCE}" ] && [ "${DRUPAL_INSTANCE}" != "dev" ] ;
   then
     # TODO:  This fails and needs to be fixed or factored out
-    perform_runtime_config "${site_url}" || printf "\n\nWARNING: runtime config failed, ignoring\n\n"
+    perform_runtime_config "${site}" || printf "\n\nWARNING: runtime config failed, ignoring\n\n"
   fi
 
   # Disable maintenance mode

--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -112,7 +112,6 @@ function perform_runtime_config {
   # Ensure that settings which depend on environment variables like service urls are set dynamically on startup.
   configure_islandora_module_local "${site}"
   configure_islandora_default_module_local "${site}"
-  configure_matomo_module_local "${site}"
   configure_openseadragon_local "${site}"
 
   # Settings like the hash / flystem can be affected by environment variables at runtime.


### PR DESCRIPTION
Correct parameters supplied to `perform_runtime_config`.

Closes #10 

## To test
1. Build images (`./gradlew build`), copy the newly created image tag.
1. Head over to `idc-isle-dc` and set the value of TAG in `.env`
1. Execute `make static-docker-compose.yml`.  If a cached (previously built) image exists, remove it and re-run the make command.
1. Edit `docker-compose.yml` and add `DRUPAL_IGNORE_STARTUP_ERRORS: "true"` to the `drupal` `environment`.
1. `make up`
1. Tail startup log of `drupal` and observe that whilst config-import fails, the runtime configuration succeeds
1. Proceed to create a repository item (say an image) with the Open Sea Dragon display hint selected, then add an Image Media with use `Preservation Master File`.  Observe that the thumbnail and service derivatives are created.   Observe that OSD works.