### PR TITLE
Exclude unused or unstable images from build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build Docker images
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build '-Prepository=${{ secrets.REPOSITORY }}' --info
+        arguments: build '-Prepository=${{ secrets.REPOSITORY }}' --info -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build
     - name: Push Docker images
       uses: eskatos/gradle-command-action@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build Docker images
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build '-Prepository=${{ secrets.REPOSITORY }}' --info -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build
+        arguments: build '-Prepository=${{ secrets.REPOSITORY }}' --info -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build -x fcrepo:build -x blazegraph:build
     - name: Push Docker images
       uses: eskatos/gradle-command-action@v1
       with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Build Docker images
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --info -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build
+        arguments: build --info -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build -x fcrepo:build -x blazegraph:build
     # @todo add tests.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Build Docker images
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build --info
+        arguments: build --info -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build
     # @todo add tests.


### PR DESCRIPTION
- recast, milliner, postgres, and matomo aren't used
- demo has proven unstable, with PHP version conflicts

GitHub Actions build log should have a line like:

``Tasks that were excluded: [task ':demo:build', task ':recast:build', task ':milliner:build', task ':postgresql:build', task ':matomo:build']``