### PR TITLE
Update CI workflows to execute isle-dc tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,17 @@ jobs:
     name: Build and Push Docker Images
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      image-tag: ${{ steps.output-image-tag.outputs.image-tag }}
+    defaults:
+      run:
+        working-directory: buildkit
     steps:
-    - name: Checkout
+    - name: Checkout idc-isle-buildkit
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        path: buildkit
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
@@ -31,11 +37,48 @@ jobs:
       run: |
         echo '{"experimental": "enabled"}' > ~/.docker/config.json
     - name: Build Docker images
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build '-Prepository=${{ secrets.REPOSITORY }}' --info -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build -x fcrepo:build -x blazegraph:build
+      # N.B. when projects are excluded from building (e.g '-x <project>:build'), they also need to be excluded from pushing, below (e.g. '-x <project>:push')
+      run: ./gradlew --console plain build '-Prepository=${{ secrets.REPOSITORY }}' -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build -x fcrepo:build -x blazegraph:build
     - name: Push Docker images
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: push '-Prepository=${{ secrets.REPOSITORY }}' '-PregistryUrl=${{ secrets.REGISTRY_URL }}' '-PregistryUsername=${{ secrets.REGISTRY_USER }}' '-PregistryPassword=${{ secrets.REGISTRY_PASS }}' --info -x demo:push -x matomo:push -x recast:push -x milliner:push -x postgresql:push -x fcrepo:push -x blazegraph:push
-    # @todo add tests.
+      # N.B. when projects are excluded from building (e.g '-x <project>:build') above, they also need to be excluded from pushing (e.g. '-x <project>:push')
+      run: ./gradlew --console plain push '-Prepository=${{ secrets.REPOSITORY }}' '-PregistryUrl=${{ secrets.REGISTRY_URL }}' '-PregistryUsername=${{ secrets.REGISTRY_USER }}' '-PregistryPassword=${{ secrets.REGISTRY_PASS }}' -x demo:push -x matomo:push -x recast:push -x milliner:push -x postgresql:push -x fcrepo:push -x blazegraph:push
+    - name: Output image tag
+      id: output-image-tag
+      # Set the image tag, same used by the isle-gradle-docker-plugin
+      run: echo ::set-output name=image-tag::$(git describe --tags --always --first-parent)
+  test:
+    name: Run idc-isle-dc Tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: isle-dc
+    steps:
+      - name: Checkout idc-isle-dc
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: jhu-idc/idc-isle-dc
+          path: isle-dc
+      - name: Set image tag
+        run: |
+          echo "Using image tag ${{needs.build.outputs.image-tag}}"
+          sed -i.bak -e 's@^TAG.*$@TAG=${{needs.build.outputs.image-tag}}@' .env
+          grep TAG .env
+      - name: Make static image
+        run: make static-docker-compose.yml
+      - name: Run smoke tests
+        run: make up test
+      - name: Capture Logs
+        if: failure()
+        run: |
+          mkdir -p end-to-end/reports
+          docker-compose logs drupal > end-to-end/reports/docker-drupal.log
+          docker-compose logs > end-to-end/reports/docker-allcontainers.log
+      - name: Upload Logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: end-to-end-reports
+          path: isle-dc/end-to-end/reports

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   build:
-    name: Build and Push Docker Images
+    name: Build and Push Buildkit Docker Images
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,9 +8,17 @@ jobs:
     name: Build Docker Images
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      image-tag: ${{ steps.output-image-tag.outputs.image-tag }}
+    defaults:
+      run:
+        working-directory: buildkit
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: buildkit
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
@@ -23,7 +31,74 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Build Docker images
-      uses: eskatos/gradle-command-action@v1
+      # N.B. when projects are excluded from building (e.g '-x <project>:build'), insure that other jobs (e.g. those in main.yml) are updated.
+      run: |
+        ./gradlew build -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build -x fcrepo:build -x blazegraph:build
+    - name: Output image tag
+      id: output-image-tag
+      # Set the image tag, same used by the isle-gradle-docker-plugin
+      run: |
+        echo ::set-output name=image-tag::$(git describe --tags --always --first-parent)
+        echo IMAGE_TAG=$(git describe --tags --always --first-parent) >> $GITHUB_ENV
+    - name: Save Images
+      run: |
+        for imageid in `docker images |grep $IMAGE_TAG|awk '{print $3}'` ; do \
+          docker image save $imageid | gzip -1 > docker-image-$imageid.tar.gz ; \
+          echo "$imageid `docker image inspect -f '{{ index .RepoTags 1 }}' $imageid`" >> docker-image-metadata.txt ; \
+        done
+    - name: Upload Images
+      uses: actions/upload-artifact@v2
       with:
-        arguments: build --info -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build -x fcrepo:build -x blazegraph:build
-    # @todo add tests.
+        name: docker-images
+        path: buildkit/docker-image-*
+  test:
+    name: Run idc-isle-dc Tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: isle-dc
+    steps:
+      - name: Checkout idc-isle-dc
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: jhu-idc/idc-isle-dc
+          path: isle-dc
+      - name: Download Images
+        uses: actions/download-artifact@v2
+        with:
+          name: docker-images
+          path: isle-dc/docker-images
+      - name: Load and Tag Images
+        run: |
+          for imagefile in `ls docker-images/docker-image-*.tar.gz` ; do docker image load < $imagefile ; done
+          while read line ; do \
+            TAG=$(echo $line | awk '{print $2}') ; \
+            ID=$(echo $line | awk '{print $1}') ; \
+            docker tag $ID $TAG ; \
+          done < docker-images/docker-image-metadata.txt
+      - name: List Images
+        run: docker image ls
+      - name: Set image tag
+        run: |
+          echo "Using image tag ${{needs.build.outputs.image-tag}}"
+          sed -i.bak -e 's@^TAG.*$@TAG=${{needs.build.outputs.image-tag}}@' .env
+          egrep '^TAG' .env
+      - name: Make static image
+        run: make static-docker-compose.yml
+      - name: Run smoke tests
+        run: make up test
+      - name: Capture Logs
+        if: failure()
+        run: |
+          mkdir -p end-to-end/reports
+          docker-compose logs drupal > end-to-end/reports/docker-drupal.log
+          docker-compose logs > end-to-end/reports/docker-allcontainers.log
+      - name: Upload Logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: end-to-end-reports
+          path: isle-dc/end-to-end/reports

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
 jobs:
-  build:
-    name: Build Docker Images
+  build_and_test:
+    name: Build Docker Images and Run Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
@@ -33,72 +33,47 @@ jobs:
     - name: Build Docker images
       # N.B. when projects are excluded from building (e.g '-x <project>:build'), insure that other jobs (e.g. those in main.yml) are updated.
       run: |
-        ./gradlew build -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build -x fcrepo:build -x blazegraph:build
+        ./gradlew build -Prepository=local -x demo:build -x matomo:build -x recast:build -x milliner:build -x postgresql:build -x fcrepo:build -x blazegraph:build
     - name: Output image tag
       id: output-image-tag
       # Set the image tag, same used by the isle-gradle-docker-plugin
       run: |
-        echo ::set-output name=image-tag::$(git describe --tags --always --first-parent)
         echo IMAGE_TAG=$(git describe --tags --always --first-parent) >> $GITHUB_ENV
-    - name: Save Images
+    - name: Checkout idc-isle-dc
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        repository: jhu-idc/idc-isle-dc
+        path: isle-dc
+    - name: Set image tag
+      working-directory: isle-dc
       run: |
-        for imageid in `docker images |grep $IMAGE_TAG|awk '{print $3}'` ; do \
-          docker image save $imageid | gzip -1 > docker-image-$imageid.tar.gz ; \
-          echo "$imageid `docker image inspect -f '{{ index .RepoTags 1 }}' $imageid`" >> docker-image-metadata.txt ; \
-        done
-    - name: Upload Images
+        echo "Using image tag ${IMAGE_TAG}"
+        sed -i.bak -e 's@^TAG.*$@TAG=${IMAGE_TAG}@' .env
+        sed -i.bak -e 's@^REPOSITORY.*$@REPOSITORY=local@' .env
+        egrep '(^TAG|^REPOSITORY)' .env
+    - name: Pull and Tag Snapshot
+      working-directory: isle-dc
+      run: |
+        SNAP_TAG=$(egrep '^SNAPSHOT_TAG' .env | awk -F= '{print $2}')
+        docker pull ghcr.io/jhu-sheridan-libraries/idc-isle-dc/snapshot:$SNAP_TAG
+        docker tag ghcr.io/jhu-sheridan-libraries/idc-isle-dc/snapshot:$SNAP_TAG local/snapshot:$SNAP_TAG
+    - name: Make static image
+      working-directory: isle-dc
+      run: make static-docker-compose.yml
+    - name: Run smoke tests
+      working-directory: isle-dc
+      run: make up test
+    - name: Capture Logs
+      if: failure()
+      working-directory: isle-dc
+      run: |
+        mkdir -p end-to-end/reports
+        docker-compose logs drupal > end-to-end/reports/docker-drupal.log
+        docker-compose logs > end-to-end/reports/docker-allcontainers.log
+    - name: Upload Logs
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
-        name: docker-images
-        path: buildkit/docker-image-*
-  test:
-    name: Run idc-isle-dc Tests
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: isle-dc
-    steps:
-      - name: Checkout idc-isle-dc
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          repository: jhu-idc/idc-isle-dc
-          path: isle-dc
-      - name: Download Images
-        uses: actions/download-artifact@v2
-        with:
-          name: docker-images
-          path: isle-dc/docker-images
-      - name: Load and Tag Images
-        run: |
-          for imagefile in `ls docker-images/docker-image-*.tar.gz` ; do docker image load < $imagefile ; done
-          while read line ; do \
-            TAG=$(echo $line | awk '{print $2}') ; \
-            ID=$(echo $line | awk '{print $1}') ; \
-            docker tag $ID $TAG ; \
-          done < docker-images/docker-image-metadata.txt
-      - name: List Images
-        run: docker image ls
-      - name: Set image tag
-        run: |
-          echo "Using image tag ${{needs.build.outputs.image-tag}}"
-          sed -i.bak -e 's@^TAG.*$@TAG=${{needs.build.outputs.image-tag}}@' .env
-          egrep '^TAG' .env
-      - name: Make static image
-        run: make static-docker-compose.yml
-      - name: Run smoke tests
-        run: make up test
-      - name: Capture Logs
-        if: failure()
-        run: |
-          mkdir -p end-to-end/reports
-          docker-compose logs drupal > end-to-end/reports/docker-drupal.log
-          docker-compose logs > end-to-end/reports/docker-allcontainers.log
-      - name: Upload Logs
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: end-to-end-reports
-          path: isle-dc/end-to-end/reports
+        name: end-to-end-reports
+        path: isle-dc/end-to-end/reports


### PR DESCRIPTION
## Summary
Updates GitHub workflows to run idc-isle-dc tests using the newly built images.

1. On `pull_request` events, build the images  and then use the newly built images to run the tests from idc-isle-dc.
1. On `push` events, build _and push_ images, then use the newly built images to run tests from idc-isle-dc.

## Overview
The workflow for the `push` is split into two jobs, only the first job should be considered critical for merging future PRs to idc-isle-dc.  The workflow for the `pull_request` event is mushed into a single job, facilitating a timely build.  If the workflow for the `pull_request` event fails, the logs will need to be reviewed to determine if remediation is required.

1. Building the images: this was originally the only CI job.  If this job fails, a PR should not be merged unless there are extenuating circumstances.   If the event is a `push` event (i.e. a PR being merged to the `main` branch), the Docker images will be pushed to the GHCR according to the parameters defined in the GitHub repository secrets.
1. Running tests from the tip of idc-isle-dc with the images build from the PR.  This job is basically a smoke test; the result should be interpreted in context.  For example, if it fails unexpectedly, then remediation may be needed.  If it succeeds, there's no guarantee that commits to idc-isle-dc in the interim (between the tests passing and the PR being merged into buildkit) are compatible.   The results just give the reviewer and submitter additional context prior to merging.

> Remember that for the `pull_request` workflow, the sequence above is executed as a single job to save ~10 minutes on the build time.

## To Test
Observe the [successful outcome](https://github.com/jhu-idc/idc-isle-buildkit/runs/1558972878) of the `pull_request` event workflow from the Actions tab for this PR.  Upon merge, the workflows for the `push` event for this PR should succeed.

## Additional Notes
- The `eskatos` gradle plugin does not respect the [`build-root-directory`](https://github.com/eskatos/gradle-command-action#run-a-build-from-a-different-directory) so its use was removed.
- Pull requests from a forked repository cannot access secrets of a public upstream repository, so `pull_request` event workflows will not have access to push images to GHCR.
  - The upstream repository (in this case jhu-idc/idc-isle-buildkit) would need to be made private or we would need to switch to a branching workflow instead of a forking workflow
  - Alternately, we could respond to `pull_request_target` events and manually work around secrets access, maintaining public access to our repo and continuing to use our forking workflow
- In order to preserve the ease of interpreting idc-isle-dc test results (its outcome needs to be interpreted in context), the workflow for `pull_request` events would need to be maintained as two distinct jobs.  But docker images built in the first job must be shared with the test job using artifact uploads
  - This results in a slower build
  - Combining the jobs results in a faster build, but a failure requires slogging through the logs to see if remediation is necessary.  This may not be a huge burden for developers; the tradeoff is we get faster results without spending the time to to save, upload, and download docker images between jobs.
  - Combining the job saves 10 to 15 minutes from the build
- subsumes #13, it can be closed.