### PR TITLE
Adds DRUPAL_SKIP_COMPOSER_INSTALL env var

### DIFF
--- a/drupal/README.md
+++ b/drupal/README.md
@@ -42,6 +42,12 @@ additional settings, volumes, ports, etc.
 | DRUPAL_DEFAULT_CONFIGDIR        | /drupal/default/configdir        |                         | Install using existing config files from directory        |
 | DRUPAL_DEFAULT_INSTALL          | /drupal/default/install          | true                    | Perform install if not already installed                  |
 
+IDC-specific startup values 
+| Environment Variable            | Etcd Key                         | Default                 | Description                                               |
+| :------------------------------ | :------------------------------- | :---------------------- | :-------------------------------------------------------- |
+| DRUPAL_IGNORE_STARTUP_ERRORS    | /drupal/ignore/startup/errors    |                         | If "true", drupal will not kill the startup process if it encounters an error |
+| DRUPAL_SKIP_COMPOSER_INSTALL    | /drupal/skip/composer/install    |                         | If "true", drupal will not attempt to run `composer install` as part of its startup procedure |
+
 Additional multi-sites can be defined by adding more environment variables,
 following the above conventions, only the `DRUPAL_SITE_{SITE}_NAME` is required
 to create an additional site:

--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -130,7 +130,9 @@ function main {
   $(installed_local) || db_count=$?
 
   # Install Composer modules if necessary.
-  COMPOSER_MEMORY_LIMIT=-1 composer install
+  if [ -z "${DRUPAL_SKIP_COMPOSER_INSTALL}" ] || [ "${DRUPAL_SKIP_COMPOSER_INSTALL}" != "true" ]; then
+    COMPOSER_MEMORY_LIMIT=-1 composer install
+  fi
 
   if [ -z "${db_count}" ] || [ "${db_count}" -lt 1 ] ; then
     printf "\n\nERROR: Drupal is not installed, no pre-existing state found\n\n"


### PR DESCRIPTION
If set to "true", the Drupal startup process will not invoke `composer install`.  This is somewhat dangerous to do (since it could result in php modules not matching composer files), but in certain development and production contexts, makes sense

## To test
* Build the set of images ./gradlew build
* update TAG in idc-idle-dc to point to the new images
* edit docker-compose.yml, to the Drupal service add `DRUPAL_SKIP_COMPOSER_INSTALL: "true"`
* `make up`, and verify that the Drupal container did not do `composer install`.