### PR TITLE
Remove duplicated mariadb root password

### DIFF
--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -17,7 +17,7 @@ function execute_sql_file_local {
     local port=$(drupal_site_env "${site}" "DB_PORT")
     # must be root for the table count query to execute
     local user=root
-    local password=${MYSQL_ROOT_PASSWORD}
+    local password=${DRUPAL_DB_ROOT_PASSWORD}
 
     /usr/local/bin/execute-sql-file.sh \
         --driver "${driver}" \


### PR DESCRIPTION
We already provide DRUPAL_DB_ROOT_PASSWORD (https://github.com/jhu-idc/idc-isle-buildkit/tree/main/drupal#settings) in .env, we shouldn't need to provide MYSQL_ROOT_PASSWORD as well.

Note: that this works in a docker environment because you are throwing the entire list of environment variables at each service in docker-compose.  In Kubernetes, ECS and others, you need to provide individual environment variables, thus there is duplication.