### PR TITLE
Adding debug output to drush maintenance enable function

### DIFF
--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -52,8 +52,8 @@ function disable_maint_mode {
 function set_maint_mode {
   local site_url=$1
   local mode=$2
-  drush -y -l ${site_url} state:set system.maintenance_mode ${mode} --input-format=integer
-  drush -y -l ${site_url} cache:rebuild
+  drush -y -l ${site_url} state:set system.maintenance_mode ${mode} --input-format=integer --debug
+  drush -y -l ${site_url} cache:rebuild --debug
 }
 
 function perform_config_import {


### PR DESCRIPTION
This simple PR adds `--debug` to drush for the set_maint_mode() function. I am getting errors connecting to the database and this should help me track it down.