### PR TITLE
Expose environment variables to PHP

### DIFF
--- a/drupal/rootfs/etc/cont-init.d/97-setup-drupal-environment-variables.sh
+++ b/drupal/rootfs/etc/cont-init.d/97-setup-drupal-environment-variables.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv /bin/bash
+ENVS=$(awk 'BEGIN{for(v in ENVIRON) print v}' | grep '^DRUPAL');
+
+echo '' > /etc/nginx/drupal_fastcgi_params  
+for env in $ENVS ; do
+        echo 'fastcgi_param' $env '"'${!env}'";' >> /etc/nginx/drupal_fastcgi_params;
+done
+
+cat /etc/nginx/drupal_fastcgi_params

--- a/drupal/rootfs/etc/nginx/conf.d/default.conf
+++ b/drupal/rootfs/etc/nginx/conf.d/default.conf
@@ -8,6 +8,7 @@ server {
 
         location ~ ^/simplesaml(?<phpfile>.+?\.php)(?<pathinfo>/.*)?$ {
             include          drupal_sp_fastcgi_params;
+            include          drupal_fastcgi_params;
             include          fastcgi_params;
             fastcgi_pass     unix:/var/run/php-fpm7/php-fpm7.sock;
             fastcgi_param    SCRIPT_FILENAME $document_root$phpfile;
@@ -100,6 +101,7 @@ server {
         # latest 5.3, you should have "cgi.fix_pathinfo = 0;" in php.ini.
         # See http://serverfault.com/q/627903/94922 for details.
         include drupal_sp_fastcgi_params;
+        include drupal_fastcgi_params;
         include fastcgi_params;
         # Block httpoxy attacks. See https://httpoxy.org/.
         fastcgi_param HTTP_PROXY "";

--- a/nginx/rootfs/etc/confd/templates/www.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/www.conf.tmpl
@@ -393,7 +393,7 @@ decorate_workers_output = no
 ; Setting to "no" will make all environment variables available to PHP code
 ; via getenv(), $_ENV and $_SERVER.
 ; Default Value: yes
-clear_env = yes
+clear_env = no
 
 ; Limits the extensions of the main script FPM will allow to parse. This can
 ; prevent configuration mistakes on the web server side. You should only limit


### PR DESCRIPTION
By default, nginx does not expose environment variables to PHP applications.  This PR switches the setting so that nginx _does_ expose environment variables.  In particular, only those environment variables `DRUPAL_*` are passed along.

The net result of this PR is that we can finally reference environment variable placeholders in Drupal's settings.php.

I created a proof-of-concept PR in idc-isle-dc to illustrate the usage.  See the settings.php diff in [the PR](https://github.com/jhu-idc/idc-isle-dc/pull/63/files)
