### PR TITLE
Update various IDC stack services

### DIFF
--- a/abuild/Dockerfile
+++ b/abuild/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine:3.11.6
+FROM alpine:3.11.7
 
 RUN --mount=type=cache,target=/var/cache/apk \ 
     --mount=type=cache,target=/etc/cache/apk \

--- a/abuild/Dockerfile
+++ b/abuild/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine:3.11.7
+FROM alpine:3.12.3
 
 RUN --mount=type=cache,target=/var/cache/apk \ 
     --mount=type=cache,target=/etc/cache/apk \

--- a/abuild/README.md
+++ b/abuild/README.md
@@ -68,7 +68,7 @@ into the destination image.
 
 ## Dependencies
 
-Requires `alpine:3.11.6` docker image to build.
+Requires `alpine:3.11.7` docker image to build.
 
 ## Reference
 

--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -3,16 +3,16 @@ FROM local/java:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
-    ACTIVEMQ_VERSION="5.14.5" && \
+    ACTIVEMQ_VERSION="5.16.1" && \
     ACTIVEMQ_FILE="apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz" && \
     ACTIVEMQ_URL="https://archive.apache.org/dist/activemq/${ACTIVEMQ_VERSION}/${ACTIVEMQ_FILE}" && \
-    ACTIVEMQ_FILE_SHA256="a4bc310ccb3fb439d0ba159e43f0e08e8073caf050c95e5e07c1a6d5f3f9a86e" && \
-    ACTIVEMQ_SIG_SHA256="3bab7224602e7b2c3b660352a2e329b0ac18359aa265163438e573ff32e06c1d" && \
+    ACTIVEMQ_FILE_SHA256="43d3f3a890bffae85c6f1002e9cf950fcc1fd17f3f5e55dc3b85d39d09e2e323" && \
+    ACTIVEMQ_SIG_SHA256="e3c88ec044bc50a30da64f2beb7b7b937ca8bcdcba82d06df94e3e04ec9893c1" && \
     download.sh --url "${ACTIVEMQ_URL}" --sha256 "${ACTIVEMQ_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     download.sh --url "${ACTIVEMQ_URL}.asc" --sha256 "${ACTIVEMQ_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     install-apache-service.sh \
         --name activemq \
-        --key "62ED4DF0BACB8793" \
+        --key "1AA8CF92D409A73393D0B736BFF2EE42C8282E76" \
         --file "${DOWNLOAD_CACHE_DIRECTORY}/${ACTIVEMQ_FILE}" \
         examples webapps-demo docs
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine:3.11.7
+FROM alpine:3.12.3
 
 COPY build/download.sh /usr/local/bin
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine:3.11.6
+FROM alpine:3.11.7
 
 COPY build/download.sh /usr/local/bin
 

--- a/base/README.md
+++ b/base/README.md
@@ -7,7 +7,7 @@ It's based off off [Alpine Linux], and includes [s6 overlay] and [confd].
 
 ## Dependencies
 
-Requires `alpine:3.11.6`
+Requires `alpine:3.11.7`
 
 ## Settings
 

--- a/base/build/download.sh
+++ b/base/build/download.sh
@@ -86,6 +86,7 @@ function cmdline {
 
 function validate {
     local file=${1}
+    echo "sha256sum ${file}: " $(sha256sum "${file}" | cut -f1 -d' ')
     sha256sum "${file}" | cut -f1 -d' ' | xargs test "${CHECKSUM}" == 
 }
 

--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -12,10 +12,10 @@ RUN --mount=type=cache,target=/var/cache/apk \
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
-    CANTALOUPE_VERSION="4.1.5" && \
+    CANTALOUPE_VERSION="4.1.7" && \
     CANTALOUPE_FILE="cantaloupe-${CANTALOUPE_VERSION}.zip" && \
     CANTALOUPE_URL="https://github.com/medusa-project/cantaloupe/releases/download/v${CANTALOUPE_VERSION}/${CANTALOUPE_FILE}" && \
-    CANTALOUPE_SHA256="a117061727f1de1c0f514659ec537c080a7f540199643244d1c9cbb50d73027d" && \
+    CANTALOUPE_SHA256="2450463f97c0df8451aa5577b837cc6a9f303d86e356a9441a7c63c7c0b3bcf7" && \
     download.sh --url "${CANTALOUPE_URL}" --sha256 "${CANTALOUPE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     unzip "${DOWNLOAD_CACHE_DIRECTORY}/${CANTALOUPE_FILE}" -d /tmp && \
     CANTALOUPE_UNPACKED="${CANTALOUPE_FILE%.zip}" && \

--- a/houdini/Dockerfile
+++ b/houdini/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
     --mount=type=bind,from=imagemagick,source=/home/builder/packages/x86_64,target=/packages \
     --mount=type=bind,from=imagemagick,source=/etc/apk/keys,target=/etc/apk/keys \
     --mount=type=cache,target=/root/.composer/cache \
-    apk add /packages/imagemagick-*.apk && \
+    apk add --allow-untrusted /packages/imagemagick-*.apk && \
     composer install -d /var/www/crayfish/Houdini && \
     php /var/www/crayfish/Houdini/bin/console cache:clear && \
     ln -s /var/www/crayfish/Houdini/public /var/www/html && \

--- a/imagemagick/build/APKBUILD
+++ b/imagemagick/build/APKBUILD
@@ -5,7 +5,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
 _pkgname=ImageMagick
-pkgver=7.0.10.10
+pkgver=7.0.10.61
 pkgrel=0
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=7
@@ -196,5 +196,5 @@ _perlmagick_doc() {
 	make -j1 DESTDIR="$subpkgdir" doc_vendor_install
 }
 
-sha512sums="2c9e0f0f172572473078651d11ee1a173ec8a0965310c04c9e96f2bfa1249362fb775f23681d5d866ec6b8847125a001814ddd91dda44ae613602127819b2894  ImageMagick-7.0.10-10.tar.gz
+sha512sums="648fd61b81af503853f2f0d0a2c09d8d8e148863a706ef959bbf00fdf2db17bcc8906ee226eb025f13b1dddb2a0c284ba0d46dd971c7ca6377d9314d691e724c  ImageMagick-7.0.10-61.tar.gz
 58afb2da075a6208b6a990ff297b3a827d260687c3355198a8b4d987e1596c0b0cd78aff6f0be0e1896e537fbe44a3d467473183f5f149664ea6e6fb3d3291a9  disable-avaraging-tests.patch"

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -3,16 +3,16 @@ FROM local/java:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
-    SOLR_VERSION="7.1.0" && \
+    SOLR_VERSION="7.7.3" && \
     SOLR_FILE="solr-${SOLR_VERSION}.tgz" && \
     SOLR_URL="https://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/${SOLR_FILE}" && \
-    SOLR_FILE_SHA256="5cd25cc2634e47efbb529658d6ddd406a7cd1b211affa26563a28db2d80b8133" && \
-    SOLR_SIG_SHA256="b187742e041a7315661b414bbadc69814e2a380ce49c0c2cc7c96acf0846d03b" && \
+    SOLR_FILE_SHA256="3ec67fa430afa5b5eb43bb1cd4a659e56ee9f8541e0116d6080c0d783870baee" && \
+    SOLR_SIG_SHA256="9f2b6c346c1c7a40995bc9fdc761ce003c6ee11e29f550552f439c313775ba54" && \
     download.sh --url "${SOLR_URL}" --sha256 "${SOLR_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     download.sh --url "${SOLR_URL}.asc" --sha256 "${SOLR_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     install-apache-service.sh \
         --name solr \
-        --key "38D2EA16DDF5FC722EBC433FDC92616F177050F6" \
+        --key "CFCE5FBB920C3C745CEEE084C38FF5EC3FCFDB3E" \
         --file "${DOWNLOAD_CACHE_DIRECTORY}/${SOLR_FILE}" \ 
         docs example licenses server/solr/configsets
 

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -3,11 +3,11 @@ FROM local/java:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
-    SOLR_VERSION="7.7.3" && \
+    SOLR_VERSION="8.8.0" && \
     SOLR_FILE="solr-${SOLR_VERSION}.tgz" && \
     SOLR_URL="https://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/${SOLR_FILE}" && \
-    SOLR_FILE_SHA256="3ec67fa430afa5b5eb43bb1cd4a659e56ee9f8541e0116d6080c0d783870baee" && \
-    SOLR_SIG_SHA256="9f2b6c346c1c7a40995bc9fdc761ce003c6ee11e29f550552f439c313775ba54" && \
+    SOLR_FILE_SHA256="7318752d1d30fa2ef839eb3d2df0f2bdb2709d304aa4870b02b33b91e945b054" && \
+    SOLR_SIG_SHA256="4577e5ac15f87a5c110471520d7b829826e95224da2648b762abbc718b3c5da6" && \
     download.sh --url "${SOLR_URL}" --sha256 "${SOLR_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     download.sh --url "${SOLR_URL}.asc" --sha256 "${SOLR_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     install-apache-service.sh \

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -3,11 +3,11 @@ FROM local/java:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
-    TOMCAT_VERSION="9.0.34" && \
+    TOMCAT_VERSION="9.0.41" && \
     TOMCAT_FILE="apache-tomcat-${TOMCAT_VERSION}.tar.gz" && \
     TOMCAT_URL="https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/${TOMCAT_FILE}" && \
-    TOMCAT_FILE_SHA256="321de5b18a48ec09d2963d9faba4bfeafc7dd2203d80a2ef7e7a20b159e2120a" && \
-    TOMCAT_SIG_SHA256="40cdb1433a3e080b26a9e791409fb3840364150b2f4594e19b3f7d0c97f7c736" && \
+    TOMCAT_FILE_SHA256="6a5fc1f79f002f25480e3a50daa1fb16fdb2f0a969bc2f806c88bc550002cf71" && \
+    TOMCAT_SIG_SHA256="2bf8fe2b4a993b799a8ea6018bda46f05a00ba9931bf904c97b3e912e30d0b69" && \
     download.sh --url "${TOMCAT_URL}" --sha256 "${TOMCAT_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     download.sh --url "${TOMCAT_URL}.asc" --sha256 "${TOMCAT_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     install-apache-service.sh \


### PR DESCRIPTION
* Updates Alpine from 3.11.6 to 3.12.3
  * latest patch release of 3.12.x series, supported until 2022-05-01
    * Latest alpine line is Alpine is 3.13.x, supported until 2022-11-01.  We should move to that as soon as we can in order to attain php 7.4.x (see below).  However, that will take some effort.
  * Update php from 7.3.22 to 7.3.26.  7.3.x is supported with security releases until 06 Dec 2021;
    * Latest PHP is 7.4.x.  This is required for Drupal 9, and would be brought in with alpine 3.13.x.  Unfortunately, it doesn't build clean at the moment and would require investigation in a separate ticket.
  * Updates nginx to from 1.16.1 to 1.18, the current stable supported release
* Updates ImageMagick from 7.0.10.10 to 7.0.10.61
* Updates Tomcat from to 9.0.34 to 9.0.41
* Updates ActiveMQ from 5.14.5 to 5.16.1
* Updates SOLR from 7.1.0 to 8.8.0
* Updates Cantaloupe from from 4.1.5 to 4.1.7

Notable omissions:
* Drupal is not updated in this PR;  it will be updated in a PR to idc-isle-buildkit
* Karaf is not updated in this PR.  The version used (4.0.8) is ancient and well out of support, but would take at least a day or two of concentrated effort to get it working on a supported/contemporary Karaf.  A separate issue is appropriate for this.

Resolves  jhu-idc/idc-general#261
Resolves  jhu-idc/idc-general#284
Resolves jhu-idc/idc-general#273