### PR TITLE
Use confd for nginx config; add vars for buffers

### DIFF
--- a/drupal/README.md
+++ b/drupal/README.md
@@ -41,6 +41,10 @@ additional settings, volumes, ports, etc.
 | DRUPAL_DEFAULT_SUBDIR           | /drupal/default/subdir           | default                 | The installation profile to use                           |
 | DRUPAL_DEFAULT_CONFIGDIR        | /drupal/default/configdir        |                         | Install using existing config files from directory        |
 | DRUPAL_DEFAULT_INSTALL          | /drupal/default/install          | true                    | Perform install if not already installed                  |
+| DRUPAL_FASTCGI_BUFFERS_NUMBER   | /drupal/fastcgi/buffers/number   | 8                       | nginx fastcgi_buffers number                              |
+| DRUPAL_FASTCGI_BUFFERS_SIZE     | /drupal/fastcgi/buffers/size     | 16k                     | nginx fastcgi_buffers size                                |
+| DRUPAL_FASTCGI_BUFFER_SIZE      | /drupal/fastcgi/buffer/size      | 32k                     | nginx fastcgi_buffer size                                 |
+
 
 Additional multi-sites can be defined by adding more environment variables,
 following the above conventions, only the `DRUPAL_SITE_{SITE}_NAME` is required

--- a/drupal/rootfs/etc/confd/conf.d/default.conf.toml
+++ b/drupal/rootfs/etc/confd/conf.d/default.conf.toml
@@ -1,0 +1,7 @@
+[template]
+src = "nginx_default.conf.tmpl"
+dest = "/etc/nginx/conf.d/default.conf"
+uid = 0
+gid = 0
+mode = "0444"
+keys = [ "/" ]

--- a/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
+++ b/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
@@ -109,6 +109,11 @@ server {
         fastcgi_intercept_errors on;
         # PHP 7 socket location.
         fastcgi_pass unix:/var/run/php-fpm7/php-fpm7.sock;
+
+        # Workaround for infinitely increasing http header size due to link rels whenever 
+        # linked entities are added to Drupal metadata
+        fastcgi_buffers {{getv "/fastcgi/buffers/number" "8"}}  {{getv "/fastcgi/buffers/size" "16k"}};
+        fastcgi_buffer_size  {{getv "/fastcgi/buffer/size" "32k"}};
     }
 
     # Fighting with Styles? This little gem is amazing.


### PR DESCRIPTION
Large header sizes, which occur when Drupal (or Islandora) add dozens of
link relations to http headers, cause the rather small default header
buffers in nginx to fill, resulting in 502 errors.  This brings nginx
config under the purview of confd, and adds configuration variables for
the buffers:

* DRUPAL_FASTCGI_BUFFERS_NUMBER
* DRUPAL_FASTCGI_BUFFERS_SIZE
* DRUPAL_FASTCGI_BUFFER_SIZE

(named after the nginx param name:  `fastcgi_buffers`, `fastcgi_buffer_size`)


## To Test
I pushed images to tag `upstream-20200824-f8d1e8e-19-g9ae11c8`.  

* Go to `idc-isle-dc`, set `TAG=upstream-20200824-f8d1e8e-19-g9ae11c8` in `.env`, 
* Do `make docker-compose.yml`.

For Bethany:
Do `make up`,  Once up, create an object that used to provoke the 502 error, with lots of entity references.  Notice that an object that used to fail, doesn't fail any more out of the box

For Derek:
* Edit `docker-compose.yml`, in the `drupal` service, add environment variables such as:<pre>
      DRUPAL_FASTCGI_BUFFERS_SIZE: 1k
      DRUPAL_FASTCGI_BUFFER_SIZE: 1k
</pre>
* do `make up`
* once up, hop into the Drupal container, and look at `/etc/nginx/conf.d/default.conf`.  Find the fastcgi param values you just set.

Resolves #28 