### PR TITLE
Initial XDebug image

### DIFF
--- a/drupal-dev/Dockerfile
+++ b/drupal-dev/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:experimental
+FROM local/drupal:latest
+
+RUN apk --no-cache add pcre-dev php7-pear php7-dev gcc musl-dev make \
+  && pecl install xdebug \
+  && apk del pcre-dev
+
+COPY rootfs /
+

--- a/drupal-dev/rootfs/etc/confd/conf.d/xdebug.ini.toml
+++ b/drupal-dev/rootfs/etc/confd/conf.d/xdebug.ini.toml
@@ -4,4 +4,3 @@ dest = "/etc/php7/conf.d/xdebug.ini"
 uid = 0
 gid = 0
 mode = "0444"
-keys = [ "/" ]

--- a/drupal-dev/rootfs/etc/confd/conf.d/xdebug.ini.toml
+++ b/drupal-dev/rootfs/etc/confd/conf.d/xdebug.ini.toml
@@ -1,0 +1,7 @@
+[template]
+src = "xdebug.ini.tmpl"
+dest = "/etc/php7/conf.d/xdebug.ini"
+uid = 0
+gid = 0
+mode = "0444"
+keys = [ "/" ]

--- a/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
+++ b/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
@@ -15,6 +15,10 @@ xdebug.log={{getenv "XDEBUG_LOG" "/var/www/drupal/xdebug.log"}}
 ;https://xdebug.org/docs/install#log_level
 xdebug.log_level={{getenv "XDEBUG_LOGLEVEL" "7"}}
 
+; Useful when debugging tests, set to "trigger"
+;https://xdebug.org/docs/all_settings#start_with_request
+xdebug.start_with_request={{getenv "XDEBUG_STARTWITHREQUEST" "no"}}
+
 ; Host discovery
 
 ;https://xdebug.org/docs/all_settings#discover_client_host

--- a/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
+++ b/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
@@ -13,7 +13,7 @@ xdebug.mode={{getenv "XDEBUG_MODE" "develop,debug,trace"}}
 xdebug.log={{getenv "XDEBUG_LOG" "/var/www/drupal/xdebug.log"}}
 
 ;https://xdebug.org/docs/install#log_level
-xdebug.log_level={{getenv "XDEBUG_LOG_LEVEL" "7"}}
+xdebug.log_level={{getenv "XDEBUG_LOGLEVEL" "7"}}
 
 ; Host discovery
 

--- a/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
+++ b/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
@@ -7,20 +7,20 @@
 zend_extension=/usr/lib/php7/modules/xdebug.so
 
 ;https://xdebug.org/docs/install#mode
-xdebug.mode=develop,debug,trace
+xdebug.mode={{getv "/xdebug/mode" "develop,debug,trace"}}
 
 ;https://xdebug.org/docs/install#log
-xdebug.log=/var/www/drupal/xdebug.log
+xdebug.log={{getv "/xdebug/log" "/var/www/drupal/xdebug.log"}}
 
 ;https://xdebug.org/docs/install#log_level
-;xdebug.log_level = 7
+xdebug.log_level = {{getv "/xdebug/loglevel" "7"}}
 
 ; Host discovery
 
 ;https://xdebug.org/docs/all_settings#discover_client_host
 ;xdebug.client_host is used as a fallback if xdebug.discover_client_host is true
-;xdebug.discover_client_host=true
+xdebug.discover_client_host={{getv "/xdebug/discoverclienthost" "false"}}
 
 ;https://xdebug.org/docs/all_settings#client_host
 ;used as a fallback if xdebug.discover_client_host=true
-xdebug.client_host=host.docker.internal
+xdebug.client_host={{getv "/xdebug/clienthost" "host.docker.internal"}}

--- a/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
+++ b/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
@@ -7,20 +7,20 @@
 zend_extension=/usr/lib/php7/modules/xdebug.so
 
 ;https://xdebug.org/docs/install#mode
-xdebug.mode={{getv "/xdebug/mode" "develop,debug,trace"}}
+xdebug.mode={{getenv "XDEBUG_MODE" "develop,debug,trace"}}
 
 ;https://xdebug.org/docs/install#log
-xdebug.log={{getv "/xdebug/log" "/var/www/drupal/xdebug.log"}}
+xdebug.log={{getenv "XDEBUG_LOG" "/var/www/drupal/xdebug.log"}}
 
 ;https://xdebug.org/docs/install#log_level
-xdebug.log_level = {{getv "/xdebug/loglevel" "7"}}
+xdebug.log_level={{getenv "XDEBUG_LOG_LEVEL" "7"}}
 
 ; Host discovery
 
 ;https://xdebug.org/docs/all_settings#discover_client_host
 ;xdebug.client_host is used as a fallback if xdebug.discover_client_host is true
-xdebug.discover_client_host={{getv "/xdebug/discoverclienthost" "false"}}
+xdebug.discover_client_host={{getenv "XDEBUG_DISCOVERCLIENTLOCALHOST" "false"}}
 
 ;https://xdebug.org/docs/all_settings#client_host
 ;used as a fallback if xdebug.discover_client_host=true
-xdebug.client_host={{getv "/xdebug/clienthost" "host.docker.internal"}}
+xdebug.client_host={{getenv "XDEBUG_CLIENTHOST" "host.docker.internal"}}

--- a/drupal-dev/rootfs/etc/php7/conf.d/xdebug.ini
+++ b/drupal-dev/rootfs/etc/php7/conf.d/xdebug.ini
@@ -1,0 +1,26 @@
+;
+; This file configures XDebug when invoked by a web request.  CLI configuration is
+; controlled by the XDEBUG_CONFIG environment variable.
+;
+
+; Comment to disable this extension.
+zend_extension=/usr/lib/php7/modules/xdebug.so
+
+;https://xdebug.org/docs/install#mode
+xdebug.mode=develop,debug,trace
+
+;https://xdebug.org/docs/install#log
+xdebug.log=/var/www/drupal/xdebug.log
+
+;https://xdebug.org/docs/install#log_level
+;xdebug.log_level = 7
+
+; Host discovery
+
+;https://xdebug.org/docs/all_settings#discover_client_host
+;xdebug.client_host is used as a fallback if xdebug.discover_client_host is true
+;xdebug.discover_client_host=true
+
+;https://xdebug.org/docs/all_settings#client_host
+;used as a fallback if xdebug.discover_client_host=true
+xdebug.client_host=host.docker.internal


### PR DESCRIPTION
## About

Provides a new image, `drupal-dev` which is `FROM` the `drupal` prod image.  It builds and installs XDebug 3 (otherwise we'd need to use the edge Alpine repositories).  The `xdebug.ini` file loads the shared module into the PHP container.

Adds the following environment variables on top of whatever is found in the `drupal` image:
* `XDEBUG_LOGLEVEL`: default `7`
* `XDEBUG_LOG`: default `/var/www/drupal/xdebug.log`
* `XDEBUG_MODE`: default `develop,debug,trace`
* `XDEBUG_DISCOVERCLIENTHOST`: default `false`
* `XDEBUG_CLIENTHOST`: default `host.docker.internal`
* `XDEBUG_STARTWITHREQUEST`: default `no`

Templatizes `/etc/php7/conf.d/xdebug.ini` file for use with `confd`.  It is feasible to conditionally load the xdebug module using confd and environment variables, so if we wish to merge debug functionality into the production image, there is a path forward.