### PR TITLE
Bump to Alpine 3.12.4

### DIFF
--- a/abuild/Dockerfile
+++ b/abuild/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine:3.12.3
+FROM alpine:3.12.4
 
 RUN --mount=type=cache,target=/var/cache/apk \ 
     --mount=type=cache,target=/etc/cache/apk \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine:3.12.3
+FROM alpine:3.12.4
 
 COPY build/download.sh /usr/local/bin
 


### PR DESCRIPTION
Bumps to Alpine 3.12.4, but also is intended to provoke image re-generation for all images that descent from `base` or `abuild`, as a mechanism of workaround for [buildkit build issies](https://github.com/birkland/buildkit-error/blob/main/README.md)