### PR TITLE
Reset cache as part of startup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: Build and Push Buildkit Docker Images
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       image-tag: ${{ steps.output-image-tag.outputs.image-tag }}
     defaults:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_test:
     name: Build Docker Images and Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       image-tag: ${{ steps.output-image-tag.outputs.image-tag }}
     defaults:

--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -137,6 +137,10 @@ function main {
     exit 1
   fi
 
+  # Reset stale cache data, which can cause exceptions if modules have been updated and are
+  # run against an obsolete cache.
+  drush -l "${site_url}" cr
+
   # Enter maintenance mode, run any database hooks from updated modules,
   # import the configuration, and perform any runtime configuration affected by
   # environment variables.


### PR DESCRIPTION
Resetting the cache has no observable effect, but resolves a rare class of failures described in #37

If you wish to test, checkout [idc-isle-dc/issue-idc-general-26](https://github.com/jhu-idc/idc-isle-dc/tree/issue-idc-general-26).   If you do a `make up`, you will see Drupal fail.  Build this PR, then edit `TAG` in  `.env` to point to the images you just built.  Do `make up` and watch it succeed.

Closes #37 