### PR TITLE
Correct the certificate data in the IdP and SP metadata

### DIFF
--- a/idp/Dockerfile
+++ b/idp/Dockerfile
@@ -12,6 +12,10 @@ RUN chmod 750 /usr/local/bin/run-jetty.sh
 RUN yum -y install gettext && \
     rm -rf /var/cache/yum
 
+RUN wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_linux_amd64 && \
+    chmod 755 /usr/local/bin/yq && \
+    echo "c4343783c3361495c0d6d1eb742bba7432aa65e13e9fb8d7e201d544bcf14246  /usr/local/bin/yq" | sha256sum -c
+
 COPY --from=base /usr/local/bin/confd /usr/local/bin
 
 COPY rootfs/ /

--- a/idp/rootfs/etc/confd/templates/idp-metadata.xml.tmpl
+++ b/idp/rootfs/etc/confd/templates/idp-metadata.xml.tmpl
@@ -41,9 +41,7 @@
         <KeyDescriptor use="signing">
             <ds:KeyInfo>
                     <ds:X509Data>
-                        <ds:X509Certificate>
-{{ getv "/saml-secrets/idp/backchannel-signing-cert" }}
-                        </ds:X509Certificate>
+                        <ds:X509Certificate>${_IDP_BACKCHANNEL_CERT}</ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
 
@@ -51,9 +49,7 @@
         <KeyDescriptor use="signing">
             <ds:KeyInfo>
                     <ds:X509Data>
-                        <ds:X509Certificate>
-{{ getv "/saml-secrets/idp/signing-cert" }}
-                        </ds:X509Certificate>
+                        <ds:X509Certificate>${_IDP_SIGNING_CERT}</ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
 
@@ -61,9 +57,7 @@
         <KeyDescriptor use="encryption">
             <ds:KeyInfo>
                     <ds:X509Data>
-                        <ds:X509Certificate>
-{{ getv "/saml-secrets/idp/encryption-cert" }}
-                        </ds:X509Certificate>
+                        <ds:X509Certificate>${_IDP_ENCRYPTION_CERT}</ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
 
@@ -99,9 +93,7 @@
         <KeyDescriptor use="signing">
             <ds:KeyInfo>
                     <ds:X509Data>
-                        <ds:X509Certificate>
-{{ getv "/saml-secrets/idp/backchannel-signing-cert" }}
-                        </ds:X509Certificate>
+                        <ds:X509Certificate>${_IDP_BACKCHANNEL_CERT}</ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
 
@@ -109,9 +101,7 @@
         <KeyDescriptor use="signing">
             <ds:KeyInfo>
                     <ds:X509Data>
-                        <ds:X509Certificate>
-{{ getv "/saml-secrets/idp/signing-cert" }}
-                        </ds:X509Certificate>
+                        <ds:X509Certificate>${_IDP_SIGNING_CERT}</ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
 
@@ -119,9 +109,7 @@
         <KeyDescriptor use="encryption">
             <ds:KeyInfo>
                     <ds:X509Data>
-                        <ds:X509Certificate>
-{{ getv "/saml-secrets/idp/encryption-cert" }}
-                        </ds:X509Certificate>
+                        <ds:X509Certificate>${_IDP_ENCRYPTION_CERT}</ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
 

--- a/idp/rootfs/etc/confd/templates/sp-metadata.xml.tmpl
+++ b/idp/rootfs/etc/confd/templates/sp-metadata.xml.tmpl
@@ -9,18 +9,14 @@ and do *NOT* provide it in real time to your partners.
         <md:KeyDescriptor use="signing">
             <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
                 <ds:X509Data>
-                    <ds:X509Certificate>
-{{getv "/saml-secrets/sp/signing-cert"}}
-                    </ds:X509Certificate>
+                    <ds:X509Certificate>${_SP_SIGNING_CERT}</ds:X509Certificate>
                 </ds:X509Data>
             </ds:KeyInfo>
         </md:KeyDescriptor>
         <md:KeyDescriptor use="encryption">
             <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
                 <ds:X509Data>
-                    <ds:X509Certificate>
-{{getv "/saml-secrets/sp/signing-cert"}}
-                    </ds:X509Certificate>
+                    <ds:X509Certificate>${_SP_SIGNING_CERT}</ds:X509Certificate>
                 </ds:X509Data>
             </ds:KeyInfo>
         </md:KeyDescriptor>

--- a/idp/run-jetty.sh
+++ b/idp/run-jetty.sh
@@ -16,6 +16,9 @@ sed -i "s/^-Xmx.*$/-Xmx$JETTY_MAX_HEAP/g" /opt/shib-jetty-base/start.ini
 confd -onetime -backend file -file /run/secrets/saml_secrets -sync-only
 
 export _SP_SIGNING_CERT=$(yq eval '.saml-secrets.sp.signing-cert' /run/secrets/saml_secrets | sed -e '/^-----*/d'|tr -d '\n')
+export _IDP_SIGNING_CERT=$(yq eval '.saml-secrets.idp.signing-cert' /run/secrets/saml_secrets | sed -e '/^-----*/d'|tr -d '\n')
+export _IDP_ENCRYPTION_CERT=$(yq eval '.saml-secrets.idp.encryption-cert' /run/secrets/saml_secrets | sed -e '/^-----*/d'|tr -d '\n')
+export _IDP_BACKCHANNEL_CERT=$(yq eval '.saml-secrets.idp.backchannel-signing-cert' /run/secrets/saml_secrets | sed -e '/^-----*/d'|tr -d '\n')
 
 envsubst < /opt/shibboleth-idp/metadata/sp-metadata.xml > /tmp/sp-metadata.xml && cp /tmp/sp-metadata.xml /opt/shibboleth-idp/metadata/sp-metadata.xml
 envsubst < /opt/shibboleth-idp/metadata/idp-metadata.xml > /tmp/idp-metadata.xml && cp /tmp/idp-metadata.xml /opt/shibboleth-idp/metadata/idp-metadata.xml

--- a/idp/run-jetty.sh
+++ b/idp/run-jetty.sh
@@ -15,6 +15,8 @@ sed -i "s/^-Xmx.*$/-Xmx$JETTY_MAX_HEAP/g" /opt/shib-jetty-base/start.ini
 
 confd -onetime -backend file -file /run/secrets/saml_secrets -sync-only
 
+export _SP_SIGNING_CERT=$(yq eval '.saml-secrets.sp.signing-cert' /run/secrets/saml_secrets | sed -e '/^-----*/d'|tr -d '\n')
+
 envsubst < /opt/shibboleth-idp/metadata/sp-metadata.xml > /tmp/sp-metadata.xml && cp /tmp/sp-metadata.xml /opt/shibboleth-idp/metadata/sp-metadata.xml
 envsubst < /opt/shibboleth-idp/metadata/idp-metadata.xml > /tmp/idp-metadata.xml && cp /tmp/idp-metadata.xml /opt/shibboleth-idp/metadata/idp-metadata.xml
 envsubst < /opt/shibboleth-idp/conf/attribute-filter.xml > /tmp/attribute-filter.xml && cp /tmp/attribute-filter.xml /opt/shibboleth-idp/conf/attribute-filter.xml


### PR DESCRIPTION
Corrects the [encoding of a certificate](https://www.w3.org/TR/xmldsig-core1/#sec-X509Data) according to the XML digital signature standard version 1.1.