### PR TITLE
Add imagemagick to Drupal image

### DIFF
--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -1,9 +1,15 @@
 # syntax=docker/dockerfile:experimental
+FROM local/imagemagick:latest as imagemagick
+
 FROM local/nginx:latest
 
 RUN --mount=type=cache,target=/etc/cache/apk \
+    --mount=type=bind,from=imagemagick,source=/home/builder/packages/x86_64,target=/packages \
+    --mount=type=bind,from=imagemagick,source=/etc/apk/keys,target=/etc/apk/keys \
     apk-install.sh \
       patch && \
+    apk add --allow-untrusted /packages/imagemagick-*.apk && \
+    apk add potrace && \
     cleanup.sh
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \


### PR DESCRIPTION
This allows us to potentially configure Drupal to use imagemagick as its
core image API implementation, instead of the built-in GD.

When Drupal is such configured, it will invoke the `convert` binary to manipulate images or extract data from them

## To test

There's not much to test, but from an ops perspective, just verify that it's OK to install imagemagick on a web-facing container, and it's OK for Drupal to execute it.  I didn't have to adjust any privileges to allow Drupal to execute imagemagick in my own local testing.

Additionally, optionally:

* do ./gradlew build 
* do `docker run -it --rm --entrypoint=ash ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal:upstream-20200824-f8d1e8e-27-g912c808` to get a shell on the Drupal container, and execute `which convert`.  You should get a valid answer.

.. or you can trust my local result when doing that:

```
BUILD SUCCESSFUL in 2m 21s
90 actionable tasks: 63 executed, 27 up-to-date
birkland@MSEL-DRCC07:~/projects/idc-isle-buildkit$ docker run -it --rm --entrypoint=ash ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal:upstream-20200824-f8d1e8e-27-g912c808
/var/www/drupal # which convert
/usr/bin/convert
/var/www/drupal #
```

Related to jhu-idc/idc-general#333
