### PR TITLE
Set xdebug.start_with_request to 'trigger' by default.

### DIFF
--- a/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
+++ b/drupal-dev/rootfs/etc/confd/templates/xdebug.ini.tmpl
@@ -17,7 +17,7 @@ xdebug.log_level={{getenv "XDEBUG_LOGLEVEL" "7"}}
 
 ; Useful when debugging tests, set to "trigger"
 ;https://xdebug.org/docs/all_settings#start_with_request
-xdebug.start_with_request={{getenv "XDEBUG_STARTWITHREQUEST" "no"}}
+xdebug.start_with_request={{getenv "XDEBUG_STARTWITHREQUEST" "trigger"}}
 
 ; Host discovery
 


### PR DESCRIPTION
Updates the `drupal-dev` image to initiate debugging when the `XDEBUG_SESSION` cookie is present on the request.  Helps debugging to "just work" out of the box when `drupal-dev` image is used.