### PR TITLE
Remove confd from s6, effectively rendering templates on boot.

### DIFF
--- a/base/rootfs/etc/services.d/confd/finish
+++ b/base/rootfs/etc/services.d/confd/finish
@@ -1,4 +1,0 @@
-#!/usr/bin/with-contenv bash
-set -e
-
-s6-svscanctl -t /var/run/s6/services

--- a/base/rootfs/etc/services.d/confd/run
+++ b/base/rootfs/etc/services.d/confd/run
@@ -1,3 +1,0 @@
-#!/usr/bin/with-contenv bash
-set -e 
-confd-render-templates.sh --continuous


### PR DESCRIPTION
Removing `confd` from s6 will effectively result in `confd` templates being rendered only once, on boot; `confd` will no longer run periodically.

Resolves #30 