### PR TITLE
Update PHP and Nginx timeouts to align with PHP_MAX_EXECUTION_TIME.

### DIFF
--- a/crayfish/rootfs/etc/confd/templates/default.conf.tmpl
+++ b/crayfish/rootfs/etc/confd/templates/default.conf.tmpl
@@ -15,6 +15,7 @@ server {
 
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_read_timeout {{ getenv "PHP_MAX_EXECUTION_TIME" "60" }};
         # Prevents URIs that include the front controller. This will 404:
         # http://domain.tld/index.php/some-path
         # Remove the internal directive to allow URIs like this

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -37,7 +37,7 @@ Requires `islandora/base` docker image to build. Please refer to the
 | PHP_DEFAULT_SOCKET_TIMEOUT | /php/default/socket/timeout | 60      | Default timeout for socket based streams (seconds)                |
 | PHP_LOG_LEVEL              | /php/log/level              | notice  | Log level. Possible Values: alert, error, warning, notice, debug  |
 | PHP_LOG_LIMIT              | /php/log/limit              | 16384   | Log limit on number of characters in the single line              |
-| PHP_MAX_EXECUTION_TIME     | /php/max/execution/time     | 30      | Maximum execution time of each script, in seconds                 |
+| PHP_MAX_EXECUTION_TIME     | /php/max/execution/time     | 30      | Maximum execution time of each script, in seconds.  The value of this is aligned with the Nginx fastcgi parameter `fastcgi_read_timeout` and the PHP parameter `request_terminate_timeout`.  That is, setting  `/php/max/execution/time` will set `fastcgi_read_timeout` and `request_terminate_timeout` to the same values.|
 | PHP_MAX_FILE_UPLOADS       | /php/max/file/uploads       | 20      | Maximum number of files that can be uploaded via a single request |
 | PHP_MAX_INPUT_TIME         | /php/max/input/time         | 60      | Maximum amount of time each script may spend parsing request data |
 | PHP_MEMORY_LIMIT           | /php/memory/limit           | 128M    | Maximum amount of memory a script may consume                     |

--- a/nginx/rootfs/etc/confd/templates/www.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/www.conf.tmpl
@@ -337,7 +337,7 @@ pm.max_spare_servers = 3
 ; does not stop script execution for some reason. A value of '0' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-;request_terminate_timeout = 0
+request_terminate_timeout = {{ getv "/php/max/execution/time" "0" }}
 
 ; The timeout set by 'request_terminate_timeout' ini option is not engaged after
 ; application calls 'fastcgi_finish_request' or when application has finished and


### PR DESCRIPTION
Align the values of 'request_terminate_timeout' and 'fastcgi_read_timeout' with PHP_MAX_EXECUTION_TIME.

To test:
* `./gradlew nginx:build crayfish:build -Prepository=local`, and copy the tag.
* Execute: 
```
docker run --rm \
  -e PHP_MAX_EXECUTION_TIME=120 \
  local/crayfish:<tag> \
  bash -c 'cat /etc/confd/conf.d/www.conf.toml ; echo "" ; cat /etc/confd/templates/default.conf.tmpl ; echo "" ; cat /etc/nginx/conf.d/default.conf; grep max_execution_time /etc/php7/php.ini; grep request_terminate_timeout /etc/php7/php-fpm.d/www.conf'
```

You should see the crayfish container start cleanly, cat out the templates, and display the value for `PHP_MAX_EXECUTION_TIME` for `request_terminate_timeout`, `max_execution_time`, and `fastcgi_read_timeout`.