### PR TITLE
Expose PHP dynamic process manager configuration params as env vars.

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -43,6 +43,10 @@ Requires `islandora/base` docker image to build. Please refer to the
 | PHP_MEMORY_LIMIT           | /php/memory/limit           | 128M    | Maximum amount of memory a script may consume                     |
 | PHP_POST_MAX_SIZE          | /php/post/max/size          | 8M      | Maximum size of POST data that PHP will accept                    |
 | PHP_UPLOAD_MAX_FILESIZE    | /php/upload/max/filesize    | 2M      | Maximum allowed size for uploaded files                           |
+| PHP_FPM_MAX_CHILDREN       | /php/fpm/max/children       | 5       | Maximum number of child processes (when using 'dynamic' pm)       |
+| PHP_FPM_START_SERVERS      | /php/fpm/start/servers      | 2       | The number of child processes created on startup (when using 'dynamic' pm) |
+| PHP_FPM_MIN_SPARE_SERVERS  | /php/fpm/min/spare/servers  | 1       | The desired minimum number of idle server processes (when using 'dynamic' pm) |
+| PHP_FPM_MAX_SPARE_SERVERS  | /php/fpm/max/spare/servers  | 3       | The desired maximum number of idle server processes (when using 'dynamic' pm) |
 
 [FPM Documentation]: https://www.php.net/manual/en/install.fpm.configuration.php
 [FPM Logging]: https://www.php.net/manual/en/install.fpm.configuration.php

--- a/nginx/rootfs/etc/confd/templates/www.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/www.conf.tmpl
@@ -110,22 +110,22 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 5
+pm.max_children = {{ getv "/php/fpm/max/children" "5" }}
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
 ; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
-pm.start_servers = 2
+pm.start_servers = {{ getv "/php/fpm/start/servers" "2" }}
 
 ; The desired minimum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.min_spare_servers = 1
+pm.min_spare_servers = {{ getv "/php/fpm/min/spare/servers" "1" }}
 
 ; The desired maximum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.max_spare_servers = 3
+pm.max_spare_servers = {{ getv "/php/fpm/max/spare/servers" "3" }}
 
 ; The number of seconds after which an idle process will be killed.
 ; Note: Used only when pm is set to 'ondemand'


### PR DESCRIPTION

To test:
* `./gradlew nginx:build -Prepository=local`
* Run the image with custom env var values; it should start and stop cleanly, and your custom values should be displayed in the output.
```
docker run --rm \
  -e PHP_FPM_MAX_CHILDREN=20 \
  -e PHP_FPM_START_SERVERS=11 \
  -e PHP_FPM_MIN_SPARE_SERVERS=4 \
  -e PHP_FPM_MAX_SPARE_SERVERS=8 \
  local/nginx:latest \
  bash -c 'egrep \'(^pm\.max_children|^pm.*_servers)\' /etc/php7/php-fpm.d/www.conf'
```
* Run the image as above, but don't supply any custom env vars.  The image should still start and stop cleanly with the defaults.