### PR TITLE
Allow customization of HTTP-related timeouts in Alpaca.

### DIFF
--- a/alpaca/Dockerfile
+++ b/alpaca/Dockerfile
@@ -1,5 +1,19 @@
 # syntax=docker/dockerfile:experimental
+FROM local/java:latest as alpacabuild
+
+ENV ALPACA_REPO="https://github.com/jhu-idc/Alpaca"
+ENV ALPACA_BRANCH="Alpaca-1.0.3-jhu"
+
+RUN mkdir /build && \
+    cd /build && \
+    git clone -b ${ALPACA_BRANCH} ${ALPACA_REPO} . && \
+    cd /build && \
+    ./gradlew install
+
 FROM local/karaf:latest
+
+# Copy locally built Alpaca artifacts
+COPY --from=alpacabuild /root/.m2/repository /root/.m2/repository
 
 # Install common features and repos
 RUN bin/start && \

--- a/alpaca/README.md
+++ b/alpaca/README.md
@@ -78,6 +78,19 @@ additional settings, volumes, ports, etc.
 | ALPACA_OCR_HTTP_CONNECT_TIMEOUT_MS                | - | 10000  | Timeout making an HTTP connection                            |
 | ALPACA_OCR_HTTP_SOCKET_TIMEOUT_MS                 | - | 600000 | Timeout reading data from a socket                           |
 
+## HTTP redelivery variables
+
+| Environment Variable                              | Etcd key | Default Value | Description |
+|:---                                               |:---      |:---           |:---
+| ALPACA_FITS_REDELIVERYDELAY                       | /fits/redeliverydelay | 10000  | Number of milliseconds before attempting to redeliver a JMS message to the microservice HTTP endpoint, due to, e.g. a timeout |
+| ALPACA_FITS_REDELIVERYBACKOFF                     | /fits/redeliverybackoff | 1.0    | Backoff factor applied to the redelivery delay |
+| ALPACA_HOMARUS_REDELIVERYDELAY                    | /homarus/redeliverydelay | 10000  | Number of milliseconds before attempting to redeliver a JMS message to the microservice HTTP endpoint, due to, e.g. a timeout |
+| ALPACA_HOMARUS_REDELIVERYBACKOFF                  | /homarus/redeliverybackoff | 1.0    | Backoff factor applied to the redelivery delay |
+| ALPACA_HOUDINI_REDELIVERYDELAY                    | /houdini/redeliverydelay | 10000  | Number of milliseconds before attempting to redeliver a JMS message to the microservice HTTP endpoint, due to, e.g. a timeout |
+| ALPACA_HOUDINI_REDELIVERYBACKOFF                  | /houdini/redeliverybackoff | 1.0    | Backoff factor applied to the redelivery delay |
+| ALPACA_OCR_HTTP_REDELIVERYDELAY                   | /ocr/redeliverydelay | 10000  | Number of milliseconds before attempting to redeliver a JMS message to the microservice HTTP endpoint, due to, e.g. a timeout |
+| ALPACA_OCR_HTTP_REDELIVERYBACKOFF                 | /ocr/redeliverybackoff | 1.0    | Backoff factor applied to the redelivery delay |
+
 ## Logs
 
 | Path                              | Description   |

--- a/alpaca/README.md
+++ b/alpaca/README.md
@@ -61,6 +61,22 @@ additional settings, volumes, ports, etc.
 | ALPACA_OCR_QUEUE                           | /alpaca/ocr/queue                          | broker:queue:islandora-connector-ocr                 | ActiveMQ Queue to consume from                                                                                                                              |
 | ALPACA_OCR_REDELIVERIES                    | /alpaca/ocr/redeliveries                   | 10                                                   | Number of attempts to redeliver if an exception occurs                                                                                                      |
 | ALPACA_OCR_SERVICE                         | /alpaca/ocr/service                        | http://hypercube:8000                                | Url of micro-service                                                                                                                                        |
+## Timeout Settings
+
+| Environment Variable                              | Etcd key | Default Value | Description |
+|:---                                               |:---      |:---           |:---
+| ALPACA_FITS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS    | - | 10000  | Timeout for retrieving a connection from the connection pool |
+| ALPACA_FITS_HTTP_CONNECT_TIMEOUT_MS               | - | 10000  | Timeout making an HTTP connection                            |
+| ALPACA_FITS_HTTP_SOCKET_TIMEOUT_MS                | - | 600000 | Timeout reading data from a socket                           |
+| ALPACA_HOMERUS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS | - | 10000  | Timeout for retrieving a connection from the connection pool |
+| ALPACA_HOMERUS_HTTP_CONNECT_TIMEOUT_MS            | - | 10000  | Timeout making an HTTP connection                            |
+| ALPACA_HOMERUS_HTTP_SOCKET_TIMEOUT_MS             | - | 600000 | Timeout reading data from a socket                           |
+| ALPACA_HOUDINI_HTTP_CONNECTION_REQUEST_TIMEOUT_MS | - | 10000  | Timeout for retrieving a connection from the connection pool |
+| ALPACA_HOUDINI_HTTP_CONNECT_TIMEOUT_MS            | - | 10000  | Timeout making an HTTP connection                            |
+| ALPACA_HOUDINI_HTTP_SOCKET_TIMEOUT_MS             | - | 600000 | Timeout reading data from a socket                           |
+| ALPACA_OCR_HTTP_CONNECTION_REQUEST_TIMEOUT_MS     | - | 10000  | Timeout for retrieving a connection from the connection pool |
+| ALPACA_OCR_HTTP_CONNECT_TIMEOUT_MS                | - | 10000  | Timeout making an HTTP connection                            |
+| ALPACA_OCR_HTTP_SOCKET_TIMEOUT_MS                 | - | 600000 | Timeout reading data from a socket                           |
 
 ## Logs
 

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.fits.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.fits.blueprint.xml.tmpl
@@ -18,8 +18,19 @@
 
   <reference id="broker" interface="org.apache.camel.Component" filter="(osgi.jndi.service.name=fcrepo/Broker)"/>
 
-  <bean id="http" class="org.apache.camel.component.http4.HttpComponent"/>
-  <bean id="https" class="org.apache.camel.component.http4.HttpComponent"/>
+  <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
+    <property name="connectionRequestTimeoutMs" value="{{ getenv "ALPACA_FITS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000" }}"/>
+    <property name="connectTimeoutMs" value="{{ getenv "ALPACA_FITS_HTTP_CONNECT_TIMEOUT_MS" "10000" }}"/>
+    <property name="socketTimeoutMs" value="{{ getenv "ALPACA_FITS_HTTP_SOCKET_TIMEOUT_MS" "600000" }}"/>
+  </bean>
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
+
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
 
   <camelContext id="IslandoraConnectorFits" xmlns="http://camel.apache.org/schema/blueprint">
     <package>ca.islandora.alpaca.connector.derivative</package>

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.fits.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.fits.blueprint.xml.tmpl
@@ -11,6 +11,8 @@
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.fits" update-strategy="reload" >
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="{{ getv "/fits/redeliveries" "10" }}"/>
+      <cm:property name="error.redeliveryDelay" value="{{ getv "/fits/redeliverydelay" "10000" }}"/>
+      <cm:property name="error.backoff" value="{{ getv "/fits/redeliverybackoff" "1.0" }}"/>
       <cm:property name="in.stream" value="{{ getv "/fits/queue" "broker:queue:islandora-connector-fits" }}"/>
       <cm:property name="derivative.service.url" value="{{ getv "/fits/service" "http://crayfits:8000" }}"/>
     </cm:default-properties>

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.homarus.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.homarus.blueprint.xml.tmpl
@@ -18,8 +18,19 @@
 
   <reference id="broker" interface="org.apache.camel.Component" filter="(osgi.jndi.service.name=fcrepo/Broker)"/>
 
-  <bean id="http" class="org.apache.camel.component.http4.HttpComponent"/>
-  <bean id="https" class="org.apache.camel.component.http4.HttpComponent"/>
+  <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
+    <property name="connectionRequestTimeoutMs" value="{{ getenv "ALPACA_HOMERUS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000" }}"/>
+    <property name="connectTimeoutMs" value="{{ getenv "ALPACA_HOMERUS_HTTP_CONNECT_TIMEOUT_MS" "10000" }}"/>
+    <property name="socketTimeoutMs" value="{{ getenv "ALPACA_HOMERUS_HTTP_SOCKET_TIMEOUT_MS" "600000" }}"/>
+  </bean>
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
+
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
 
   <camelContext id="IslandoraConnectorHomarus" xmlns="http://camel.apache.org/schema/blueprint">
     <package>ca.islandora.alpaca.connector.derivative</package>

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.homarus.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.homarus.blueprint.xml.tmpl
@@ -11,6 +11,8 @@
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.homarus" update-strategy="reload" >
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="{{ getv "/homarus/redeliveries" "10" }}"/>
+      <cm:property name="error.redeliveryDelay" value="{{ getv "/homarus/redeliverydelay" "10000" }}"/>
+      <cm:property name="error.backoff" value="{{ getv "/homarus/redeliverybackoff" "1.0" }}"/>
       <cm:property name="in.stream" value="{{ getv "/homarus/queue" "broker:queue:islandora-connector-homarus" }}"/>
       <cm:property name="derivative.service.url" value="{{ getv "/homarus/service" "http://homarus:8000/convert" }}"/>
     </cm:default-properties>

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.houdini.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.houdini.blueprint.xml.tmpl
@@ -18,8 +18,19 @@
 
   <reference id="broker" interface="org.apache.camel.Component" filter="(osgi.jndi.service.name=fcrepo/Broker)"/>
 
-  <bean id="http" class="org.apache.camel.component.http4.HttpComponent"/>
-  <bean id="https" class="org.apache.camel.component.http4.HttpComponent"/>
+  <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
+    <property name="connectionRequestTimeoutMs" value="{{ getenv "ALPACA_HOUDINI_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000" }}"/>
+    <property name="connectTimeoutMs" value="{{ getenv "ALPACA_HOUDINI_HTTP_CONNECT_TIMEOUT_MS" "10000" }}"/>
+    <property name="socketTimeoutMs" value="{{ getenv "ALPACA_HOUDINI_HTTP_SOCKET_TIMEOUT_MS" "600000" }}"/>
+  </bean>
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
+
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
 
   <camelContext id="IslandoraConnectorHoudini" xmlns="http://camel.apache.org/schema/blueprint">
     <package>ca.islandora.alpaca.connector.derivative</package>

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.houdini.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.houdini.blueprint.xml.tmpl
@@ -11,6 +11,8 @@
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.houdini" update-strategy="reload" >
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="{{ getv "/houdini/redeliveries" "10" }}"/>
+      <cm:property name="error.redeliveryDelay" value="{{ getv "/houdini/redeliverydelay" "10000" }}"/>
+      <cm:property name="error.backoff" value="{{ getv "/houdini/redeliverybackoff" "1.0" }}"/>
       <cm:property name="in.stream" value="{{ getv "/houdini/queue" "broker:queue:islandora-connector-houdini" }}"/>
       <cm:property name="derivative.service.url" value="{{ getv "/houdini/service" "http://houdini:8000/convert" }}"/>
     </cm:default-properties>

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.ocr.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.ocr.blueprint.xml.tmpl
@@ -11,6 +11,8 @@
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.ocr" update-strategy="reload" >
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="{{ getv "/ocr/redeliveries" "10" }}"/>
+      <cm:property name="error.redeliveryDelay" value="{{ getv "/ocr/redeliverydelay" "10000" }}"/>
+      <cm:property name="error.backoff" value="{{ getv "/ocr/redeliverybackoff" "1.0" }}"/>
       <cm:property name="in.stream" value="{{ getv "/ocr/queue" "broker:queue:islandora-connector-ocr" }}"/>
       <cm:property name="derivative.service.url" value="{{ getv "/ocr/service" "http://hypercube:8000" }}"/>
     </cm:default-properties>

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.ocr.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.ocr.blueprint.xml.tmpl
@@ -18,8 +18,19 @@
 
   <reference id="broker" interface="org.apache.camel.Component" filter="(osgi.jndi.service.name=fcrepo/Broker)"/>
 
-  <bean id="http" class="org.apache.camel.component.http4.HttpComponent"/>
-  <bean id="https" class="org.apache.camel.component.http4.HttpComponent"/>
+  <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
+    <property name="connectionRequestTimeoutMs" value="{{ getenv "ALPACA_OCR_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000" }}"/>
+    <property name="connectTimeoutMs" value="{{ getenv "ALPACA_OCR_HTTP_CONNECT_TIMEOUT_MS" "10000" }}"/>
+    <property name="socketTimeoutMs" value="{{ getenv "ALPACA_OCR_HTTP_SOCKET_TIMEOUT_MS" "600000" }}"/>
+  </bean>
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
+
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent">
+    <property name="httpClientConfigurer" ref="requestConfigConfigurer"/>
+  </bean>
 
   <camelContext id="IslandoraConnectorOCR" xmlns="http://camel.apache.org/schema/blueprint">
     <package>ca.islandora.alpaca.connector.derivative</package>


### PR DESCRIPTION
This updates the Alpaca Docker image build to use our fork of Alpaca.  Our fork of Alpaca introduces two changes, and additional properties that are configurable using blueprint descriptors along with confd:
* control of HTTP timeout values
* control of HTTP-related redelivery attempts

This PR:
* Updates the Docker build to compile and use our Java artifacts for the 1.0.3 Alpaca release
* Updates the Blueprint files for the four microservices, and configures default timeouts.
* Adds environment variables (documented in the README) for adjusting timeout values for each microservice.

To test:
* `./gradlew -Prepository=local alpaca:build`
* Then execute the following and see your custom values.
```
docker run --rm \
  -e ALPACA_HOUDINI_HTTP_CONNECT_TIMEOUT_MS=5555 \
  -e ALPACA_HOUDINI_HTTP_SOCKET_TIMEOUT_MS=11111 \
  -e ALPACA_HOUDINI_HTTP_CONNECTION_REQUEST_TIMEOUT_MS=9999 \
  -e ALPACA_HOUDINI_REDELIVERYDELAY=5999 \
  -e ALPACA_HOUDINI_REDELIVERYBACKOFF=2.5 \
  local/alpaca:latest \
  bash -c 'cat deploy/ca.islandora.alpaca.connector.houdini.blueprint.xml'
```
* Execute the following to see defaults:
```
docker run --rm \
  local/alpaca:latest \
  bash -c 'cat deploy/ca.islandora.alpaca.connector.houdini.blueprint.xml'
```

Feel free to try the other documented env vars for other microservices.  Adjust the location of the blueprint file as necessary.