### PR TITLE
Add password change to startup script

### DIFF
--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -137,6 +137,9 @@ function main {
     exit 1
   fi
 
+  # Set the admin password based on env vars
+  drush -l "${site_url}" user-password admin "${DRUPAL_DEFAULT_ACCOUNT_PASSWORD}";
+
   # Reset stale cache data, which can cause exceptions if modules have been updated and are
   # run against an obsolete cache.
   drush -l "${site_url}" cr


### PR DESCRIPTION
Uses drush to explicitly change the admin password to whatever `DRUPAL_DEFAULT_ACCOUNT_PASSWORD` is set to.  Prior to this PR, this environment variable was being ignored, except upon initial installation.

Resolves jhu-idc/idc-general#332