### PR TITLE
Switch from using confd 'getv' directive to 'getenv' directive for various performance-related environment variables.

### DIFF
--- a/crayfish/README.md
+++ b/crayfish/README.md
@@ -28,4 +28,10 @@ additional settings, volumes, ports, etc.
 | :------------------- | :--------------- | :-------- | :---------- |
 | JWT_ADMIN_TOKEN      | /jwt/admin/token | islandora | JWT Token   |
 
+### Timeout configuration
+
+| Environment Variable    | Etcd Key                 | Default           | Description                                                                                       |
+| :---------------------- | :----------------------- | :---------------- | :------------------------------------------------------------------------------------------------ |
+| PHP_MAX_EXECUTION_TIME  | -                        | 60                | The value of `PHP_MAX_EXECUTION_TIME` is used to set the Nginx `fastcgi_read_timeout` parameter   |
+
 [Crayfish]: https://github.com/Islandora/Crayfish/tree/main

--- a/crayfits/README.md
+++ b/crayfits/README.md
@@ -29,4 +29,10 @@ additional settings, volumes, ports, etc.
 | CRAYFITS_LOG_LEVEL      | /crayfits/log/level      | debug             | Log level. Possible Values: debug, info, notice, warning, error, critical, alert, emergency, none |
 | CRAYFITS_WEBSERVICE_URI | /crayfits/webservice/uri | fits/fits/examine | The URL of the FITS servlet.                                                                      |
 
+### Timeout configuration
+
+| Environment Variable    | Etcd Key                 | Default           | Description                                                                                       |
+| :---------------------- | :----------------------- | :---------------- | :------------------------------------------------------------------------------------------------ |
+| PHP_MAX_EXECUTION_TIME  | -                        | 60                | The value of `PHP_MAX_EXECUTION_TIME` is used to set the Nginx `fastcgi_read_timeout` parameter   |
+
 [CrayFits]: https://github.com/roblib/CrayFits

--- a/crayfits/rootfs/etc/confd/templates/default.conf.tmpl
+++ b/crayfits/rootfs/etc/confd/templates/default.conf.tmpl
@@ -15,6 +15,7 @@ server {
 
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_read_timeout {{ getenv "PHP_MAX_EXECUTION_TIME" "60" }};
         # Prevents URIs that include the front controller. This will 404:
         # http://domain.tld/index.php/some-path
         # Remove the internal directive to allow URIs like this

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -37,7 +37,7 @@ Requires `islandora/base` docker image to build. Please refer to the
 | PHP_DEFAULT_SOCKET_TIMEOUT | /php/default/socket/timeout | 60      | Default timeout for socket based streams (seconds)                |
 | PHP_LOG_LEVEL              | /php/log/level              | notice  | Log level. Possible Values: alert, error, warning, notice, debug  |
 | PHP_LOG_LIMIT              | /php/log/limit              | 16384   | Log limit on number of characters in the single line              |
-| PHP_MAX_EXECUTION_TIME     | /php/max/execution/time     | 30      | Maximum execution time of each script, in seconds.  The value of this is aligned with the Nginx fastcgi parameter `fastcgi_read_timeout` and the PHP parameter `request_terminate_timeout`.  That is, setting  `/php/max/execution/time` will set `fastcgi_read_timeout` and `request_terminate_timeout` to the same values.|
+| PHP_MAX_EXECUTION_TIME     | -                           | 30      | Maximum execution time of each script, in seconds.  The value of this is aligned with the Nginx fastcgi parameter `fastcgi_read_timeout` and the PHP parameter `request_terminate_timeout`.  That is, setting  `/php/max/execution/time` will set `fastcgi_read_timeout` and `request_terminate_timeout` to the same values.|
 | PHP_MAX_FILE_UPLOADS       | /php/max/file/uploads       | 20      | Maximum number of files that can be uploaded via a single request |
 | PHP_MAX_INPUT_TIME         | /php/max/input/time         | 60      | Maximum amount of time each script may spend parsing request data |
 | PHP_MEMORY_LIMIT           | /php/memory/limit           | 128M    | Maximum amount of memory a script may consume                     |

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -43,10 +43,10 @@ Requires `islandora/base` docker image to build. Please refer to the
 | PHP_MEMORY_LIMIT           | /php/memory/limit           | 128M    | Maximum amount of memory a script may consume                     |
 | PHP_POST_MAX_SIZE          | /php/post/max/size          | 8M      | Maximum size of POST data that PHP will accept                    |
 | PHP_UPLOAD_MAX_FILESIZE    | /php/upload/max/filesize    | 2M      | Maximum allowed size for uploaded files                           |
-| PHP_FPM_MAX_CHILDREN       | /php/fpm/max/children       | 5       | Maximum number of child processes (when using 'dynamic' pm)       |
-| PHP_FPM_START_SERVERS      | /php/fpm/start/servers      | 2       | The number of child processes created on startup (when using 'dynamic' pm) |
-| PHP_FPM_MIN_SPARE_SERVERS  | /php/fpm/min/spare/servers  | 1       | The desired minimum number of idle server processes (when using 'dynamic' pm) |
-| PHP_FPM_MAX_SPARE_SERVERS  | /php/fpm/max/spare/servers  | 3       | The desired maximum number of idle server processes (when using 'dynamic' pm) |
+| PHP_FPM_MAX_CHILDREN       | -                           | 5       | Maximum number of child processes (when using 'dynamic' pm)       |
+| PHP_FPM_START_SERVERS      | -                           | 2       | The number of child processes created on startup (when using 'dynamic' pm) |
+| PHP_FPM_MIN_SPARE_SERVERS  | -                           | 1       | The desired minimum number of idle server processes (when using 'dynamic' pm) |
+| PHP_FPM_MAX_SPARE_SERVERS  | -                           | 3       | The desired maximum number of idle server processes (when using 'dynamic' pm) |
 
 [FPM Documentation]: https://www.php.net/manual/en/install.fpm.configuration.php
 [FPM Logging]: https://www.php.net/manual/en/install.fpm.configuration.php

--- a/nginx/rootfs/etc/confd/templates/php.ini.tmpl
+++ b/nginx/rootfs/etc/confd/templates/php.ini.tmpl
@@ -378,7 +378,7 @@ expose_php = On
 ; Maximum execution time of each script, in seconds
 ; http://php.net/max-execution-time
 ; Note: This directive is hardcoded to 0 for the CLI SAPI
-max_execution_time = {{ getv "/php/max/execution/time" "30" }}
+max_execution_time = {{ getenv "PHP_MAX_EXECUTION_TIME" "30" }}
 
 ; Maximum amount of time each script may spend parsing request data. It's a good
 ; idea to limit this time on productions servers in order to eliminate unexpectedly

--- a/nginx/rootfs/etc/confd/templates/www.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/www.conf.tmpl
@@ -337,7 +337,7 @@ pm.max_spare_servers = {{ getv "/php/fpm/max/spare/servers" "3" }}
 ; does not stop script execution for some reason. A value of '0' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-request_terminate_timeout = {{ getv "/php/max/execution/time" "0" }}
+request_terminate_timeout = {{ getenv "PHP_MAX_EXECUTION_TIME" "0" }}
 
 ; The timeout set by 'request_terminate_timeout' ini option is not engaged after
 ; application calls 'fastcgi_finish_request' or when application has finished and

--- a/nginx/rootfs/etc/confd/templates/www.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/www.conf.tmpl
@@ -110,22 +110,22 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = {{ getv "/php/fpm/max/children" "5" }}
+pm.max_children = {{ getenv "PHP_FPM_MAX_CHILDREN" "5" }}
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
 ; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
-pm.start_servers = {{ getv "/php/fpm/start/servers" "2" }}
+pm.start_servers = {{ getenv "PHP_FPM_START_SERVERS" "2" }}
 
 ; The desired minimum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.min_spare_servers = {{ getv "/php/fpm/min/spare/servers" "1" }}
+pm.min_spare_servers = {{ getenv "PHP_FPM_MIN_SPARE_SERVERS" "1" }}
 
 ; The desired maximum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.max_spare_servers = {{ getv "/php/fpm/max/spare/servers" "3" }}
+pm.max_spare_servers = {{ getenv "PHP_FPM_MAX_SPARE_SERVERS" "3" }}
 
 ; The number of seconds after which an idle process will be killed.
 ; Note: Used only when pm is set to 'ondemand'

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -44,6 +44,7 @@ additional settings, volumes, ports, etc.
 | TOMCAT_ADMIN_ROLES                  | /tomcat/admin/roles                  | manager-gui | Comma separated list of roles the user has                                            |
 | TOMCAT_LOG_LEVEL                    | /tomcat/log/level                    | ALL         | Log level. Possible Values: SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST or ALL |
 | TOMCAT_MANAGER_REMOTE_ADDRESS_VALVE | /tomcat/manager/remote/address/valve | ^.*$        | Allows / blocks access to manager app to addresses which match this regex             |
+| TOMCAT_NGINX_PROXY_READ_TIMEOUT     | -                                    | 60          | Defines a timeout for reading a response from the proxied server, in seconds. |
 
 Additional users/groups/etc can be defined by adding more environment variables,
 following the above conventions:

--- a/tomcat/rootfs/etc/confd/templates/default.conf.tmpl
+++ b/tomcat/rootfs/etc/confd/templates/default.conf.tmpl
@@ -5,5 +5,6 @@ server {
         proxy_set_header   X-Forwarded-For $remote_addr;
         proxy_set_header   Host $http_host;
         proxy_pass         "http://127.0.0.1:8080";
+        proxy_read_timeout {{ getenv "TOMCAT_NGINX_PROXY_READ_TIMEOUT" "60" }};
     }
 }


### PR DESCRIPTION
This PR follows up on #45 and #46 which were deficient.  

This PR updates the relevant configuration to use the confd `getenv` directive rather than `getv`, updates READMEs, and adds `TOMCAT_NGINX_PROXY_READ_TIMEOUT` to the `tomcat` image.

The basic test scenario is to run the relevant image setting an environment variable, and observing its value in the affected configuration file.

To run the tests, you must first build the affected images:
* `./gradlew -Prepository=local nginx:build crayfish:build houdini:build homarus:build hypercube:build tomcat:build`

### Timeout-related environment variables

To test:
* To test a custom value (in this example `499`) run the following and observe the custom value in three locations for each image:
```shell
for i in homarus houdini hypercube ; do \
  docker run --rm \
  -e PHP_MAX_EXECUTION_TIME=499 \
  local/$i:latest \
  bash -c 'grep fastcgi_read_timeout /etc/nginx/conf.d/default.conf; \
  egrep ^max_execution_time /etc/php7/php.ini; \
  egrep ^request_terminate_timeout /etc/php7/php-fpm.d/www.conf' 2>&1 | \
  egrep '(fastcgi_read_timeout|^max_execution_time|^request_terminate_timeout)' ; done
```
* Run the following to see the default values of `30`, `60` and `0` respectively:
```shell
for i in homarus houdini hypercube ; do \
  docker run --rm \
  local/$i:latest \
  bash -c 'grep fastcgi_read_timeout /etc/nginx/conf.d/default.conf; \
  egrep ^max_execution_time /etc/php7/php.ini; \
  egrep ^request_terminate_timeout /etc/php7/php-fpm.d/www.conf' 2>&1 | \
  egrep '(fastcgi_read_timeout|^max_execution_time|^request_terminate_timeout)' ; done
```

* Verify the `TOMCAT_NGINX_PROXY_READ_TIMEOUT` can be set (in this example to `120`):
```shell
docker run --rm -e TOMCAT_NGINX_PROXY_READ_TIMEOUT=120 \
 local/tomcat:latest \
 bash -c 'grep proxy_read_timeout /etc/nginx/conf.d/default.conf' 2>&1 |grep proxy_read_timeout
```
* and for the default:
```shell
docker run --rm local/tomcat:latest \
bash -c 'grep proxy_read_timeout /etc/nginx/conf.d/default.conf' 2>&1 |grep proxy_read_timeout
```
> Note `TOMCAT_NGINX_PROXY_READ_TIMEOUT` is newly introduced in this PR.

### PHP Process Manager variables

* Verify that the various PHP-FPM process manager variables can be set:
```shell
for i in homarus hypercube houdini ; do \
docker run --rm \
-e PHP_FPM_MAX_CHILDREN=10 \
-e PHP_FPM_START_SERVERS=20 \
-e PHP_FPM_MAX_CHILDREN=25 \
-e PHP_FPM_MIN_SPARE_SERVERS=10 \
-e PHP_FPM_MAX_SPARE_SERVERS=12 \
local/$i:latest bash -c 'egrep ^pm\. /etc/php7/php-fpm.d/www.conf' 2>&1 | egrep '^pm\.' ;  done
```
* And view their defaults:
```shell
for i in homarus hypercube houdini ; do \
docker run --rm \
local/$i:latest bash -c 'egrep ^pm\. /etc/php7/php-fpm.d/www.conf' 2>&1 | egrep '^pm\.' ;  done
```