### PR TITLE
Remove duplicate Houdini Camel context from Alpaca

### DIFF
--- a/alpaca/Dockerfile
+++ b/alpaca/Dockerfile
@@ -2,7 +2,10 @@
 FROM local/java:latest as alpacabuild
 
 ENV ALPACA_REPO="https://github.com/jhu-idc/Alpaca"
-ENV ALPACA_BRANCH="Alpaca-1.0.3-jhu"
+# Typically ALPACA_BRANCH should reference the tip of the Alpaca-1.0.3-jhu branch.
+# Using commit hashes ensures that no commits are pulled inadvertantly, and requires
+# a commit to the buildkit repo to advance Alpaca.
+ENV ALPACA_BRANCH=4c23ae95e75ced89e0da272c5b0dae85604fcee7
 
 RUN mkdir /build && \
     cd /build && \

--- a/alpaca/Dockerfile
+++ b/alpaca/Dockerfile
@@ -2,15 +2,16 @@
 FROM local/java:latest as alpacabuild
 
 ENV ALPACA_REPO="https://github.com/jhu-idc/Alpaca"
-# Typically ALPACA_BRANCH should reference the tip of the Alpaca-1.0.3-jhu branch.
+ENV ALPACA_BRANCH=Alpaca-1.0.3-jhu
+# Typically ALPACA_COMMIT should reference the tip of the Alpaca-1.0.3-jhu branch.
 # Using commit hashes ensures that no commits are pulled inadvertantly, and requires
 # a commit to the buildkit repo to advance Alpaca.
-ENV ALPACA_BRANCH=4c23ae95e75ced89e0da272c5b0dae85604fcee7
+ENV ALPACA_COMMIT=4c23ae95e75ced89e0da272c5b0dae85604fcee7
 
 RUN mkdir /build && \
     cd /build && \
     git clone -b ${ALPACA_BRANCH} ${ALPACA_REPO} . && \
-    cd /build && \
+    git checkout ${ALPACA_COMMIT} && \
     ./gradlew install
 
 FROM local/karaf:latest


### PR DESCRIPTION
Alpaca 1.0.3 includes a blueprint descriptor in the connector's OSGI bundle.  ISLE provides blueprint descriptors as well.  When Alpaca starts, the ISLE-provided descriptors and the descriptor included in the bundle start.  This results in two Houdini Camel contexts, which results in multiple endpoints reading from the houdini queue.

This PR updates to the lastest Alpaca, which removes the bundle-provided blueprint descriptor and the duplicate Houdini context.

To test:
* before applying this PR, start ISLE and list the camel contexts.  you'll see two Houdini contexts.
  * `docker-compose exec alpaca bin/client camel:context-list`
* apply this PR, build new images, update `.env` to point to the newly built images, and start ISLE 
* list the camel contexts, you should see only one Houdini context
  *  `docker-compose exec alpaca bin/client camel:context-list`