### PR TITLE
Remove unused features from Alpaca.

### DIFF
--- a/alpaca/Dockerfile
+++ b/alpaca/Dockerfile
@@ -35,19 +35,6 @@ RUN bin/start && \
     bin/stop && \
     rm -rf instances/*
 
-# Fcrepo indexing
-RUN bin/start && \
-    bin/client -r 10 -d 5  "feature:install islandora-indexing-fcrepo" && \
-    bin/stop && \
-    rm -rf instances/*
-
-# Triple indexing
-RUN bin/start && \
-    bin/client -r 10 -d 5  "feature:install fcrepo-indexing-triplestore" && \
-    bin/client -r 10 -d 5  "feature:install islandora-indexing-triplestore" && \
-    bin/stop && \
-    rm -rf instances/*
-
 RUN chown -R karaf:karaf /opt/karaf
 
 COPY rootfs /


### PR DESCRIPTION
Removes Fedora-related features from Alpaca which we are not using.

To test:
* prior to applying this PR, start ISLE and observe a number of Fedora-related Camel contexts including:
  * `FcrepoIndexer`, `FcrepoTriplestoreIndexer`, `IslandoraTriplestoreIndexer`
  * docker-compose exec alpaca bin/client camel:context-list
* build the images supplied by this PR, update ISLE `.env` to point to the new images, and (re)start ISLE
* list the contexts, and note that the Fedora-related contexts are no longer thereL
  * `FcrepoIndexer`, `FcrepoTriplestoreIndexer`, `IslandoraTriplestoreIndexer`