### PR TITLE
Alpaca default http timeouts

### DIFF
--- a/alpaca/README.md
+++ b/alpaca/README.md
@@ -35,6 +35,12 @@ additional settings, volumes, ports, etc.
 | ALPACA_FCREPO_AUTH_PASSWORD                | /alpaca/fcrepo/auth/password               |                                                      | Password to authenticate with                                                                                                                               |
 | ALPACA_FCREPO_AUTH_USER                    | /alpaca/fcrepo/auth/user                   |                                                      | URL to authenticate against                                                                                                                                 |
 | ALPACA_FCREPO_URL                          | /alpaca/fcrepo/url                         | http://fcrepo/fcrepo/rest                            | The url of fcrepo rest API                                                                                                                                  |
+| ALPACA_REDELIVERIES                        | -                                          | 10                                                   | Number of attempts to redeliver if an exception occurs                                                                                                      |
+| ALPACA_REDELIVERYDELAY                     | -                                          | 10000                                                | Number of milliseconds before attempting to redeliver a JMS message to the microservice HTTP endpoint, due to, e.g. a timeout                               |
+| ALPACA_REDELIVERYBACKOFF                   | -                                          | 1.0                                                  | Backoff factor applied to the redelivery delay                                                                                                              |
+| ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS  | -                                          | 10000                                                | Timeout for retrieving a connection from the connection pool                                                                                                |
+| ALPACA_HTTP_CONNECT_TIMEOUT_MS             | -                                          | 10000                                                | Timeout making an HTTP connection                                                                                                                           |
+| ALPACA_HTTP_SOCKET_TIMEOUT_MS              | -                                          | 600000                                               | Timeout reading data from a socket                                                                                                                          |                 
 | ALPACA_FITS_QUEUE                          | /alpaca/fits/queue                         | broker:queue:islandora-connector-fits                | ActiveMQ Queue to consume from                                                                                                                              |
 | ALPACA_FITS_REDELIVERIES                   | /alpaca/fits/redeliveries                  | 10                                                   | Number of attempts to redeliver if an exception occurs                                                                                                      |
 | ALPACA_FITS_SERVICE                        | /alpaca/fits/service                       | http://crayfits:8000                                 | Url of micro-service                                                                                                                                        |
@@ -68,18 +74,18 @@ additional settings, volumes, ports, etc.
 
 | Environment Variable                              | Etcd key | Default Value | Description |
 |:---                                               |:---      |:---           |:---
-| ALPACA_FITS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS    | - | 10000  | Timeout for retrieving a connection from the connection pool |
-| ALPACA_FITS_HTTP_CONNECT_TIMEOUT_MS               | - | 10000  | Timeout making an HTTP connection                            |
-| ALPACA_FITS_HTTP_SOCKET_TIMEOUT_MS                | - | 600000 | Timeout reading data from a socket                           |
-| ALPACA_HOMERUS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS | - | 10000  | Timeout for retrieving a connection from the connection pool |
-| ALPACA_HOMERUS_HTTP_CONNECT_TIMEOUT_MS            | - | 10000  | Timeout making an HTTP connection                            |
-| ALPACA_HOMERUS_HTTP_SOCKET_TIMEOUT_MS             | - | 600000 | Timeout reading data from a socket                           |
-| ALPACA_HOUDINI_HTTP_CONNECTION_REQUEST_TIMEOUT_MS | - | 10000  | Timeout for retrieving a connection from the connection pool |
-| ALPACA_HOUDINI_HTTP_CONNECT_TIMEOUT_MS            | - | 10000  | Timeout making an HTTP connection                            |
-| ALPACA_HOUDINI_HTTP_SOCKET_TIMEOUT_MS             | - | 600000 | Timeout reading data from a socket                           |
-| ALPACA_OCR_HTTP_CONNECTION_REQUEST_TIMEOUT_MS     | - | 10000  | Timeout for retrieving a connection from the connection pool |
-| ALPACA_OCR_HTTP_CONNECT_TIMEOUT_MS                | - | 10000  | Timeout making an HTTP connection                            |
-| ALPACA_OCR_HTTP_SOCKET_TIMEOUT_MS                 | - | 600000 | Timeout reading data from a socket                           |
+| ALPACA_FITS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS    | /alpaca/fits/http/connection/request/timeout/ms    | 10000  | Timeout for retrieving a connection from the connection pool |
+| ALPACA_FITS_HTTP_CONNECT_TIMEOUT_MS               | /alpaca/fits/http/connect/timeout/ms               | 10000  | Timeout making an HTTP connection                            |
+| ALPACA_FITS_HTTP_SOCKET_TIMEOUT_MS                | /alpaca/fits/http/socket/timeout/ms                | 600000 | Timeout reading data from a socket                           |
+| ALPACA_HOMERUS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS | /alpaca/homerus/http/connection/request/timeout/ms | 10000  | Timeout for retrieving a connection from the connection pool |
+| ALPACA_HOMERUS_HTTP_CONNECT_TIMEOUT_MS            | /alpaca/homerus/http/connect/timeout/ms            | 10000  | Timeout making an HTTP connection                            |
+| ALPACA_HOMERUS_HTTP_SOCKET_TIMEOUT_MS             | /alpaca/homerus/http/socket/timeout/ms             | 600000 | Timeout reading data from a socket                           |
+| ALPACA_HOUDINI_HTTP_CONNECTION_REQUEST_TIMEOUT_MS | /alpaca/houdini/http/connection/request/timeout/ms | 10000  | Timeout for retrieving a connection from the connection pool |
+| ALPACA_HOUDINI_HTTP_CONNECT_TIMEOUT_MS            | /alpaca/houdini/http/connect/timeout/ms            | 10000  | Timeout making an HTTP connection                            |
+| ALPACA_HOUDINI_HTTP_SOCKET_TIMEOUT_MS             | /alpaca/houdini/http/socket/timeout/ms             | 600000 | Timeout reading data from a socket                           |
+| ALPACA_OCR_HTTP_CONNECTION_REQUEST_TIMEOUT_MS     | /alpaca/ocr/http/connection/request/timeout/ms     | 10000  | Timeout for retrieving a connection from the connection pool |
+| ALPACA_OCR_HTTP_CONNECT_TIMEOUT_MS                | /alpaca/ocr/http/connect/timeout/ms                | 10000  | Timeout making an HTTP connection                            |
+| ALPACA_OCR_HTTP_SOCKET_TIMEOUT_MS                 | /alpaca/ocr/http/socket/timeout/ms                 | 600000 | Timeout reading data from a socket                           |
 
 ## JMS Tuning Variables
 

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.fits.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.fits.blueprint.xml.tmpl
@@ -10,9 +10,12 @@
 
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.fits" update-strategy="reload" >
     <cm:default-properties>
-      <cm:property name="error.maxRedeliveries" value="{{ getv "/fits/redeliveries" "10" }}"/>
-      <cm:property name="error.redeliveryDelay" value="{{ getv "/fits/redeliverydelay" "10000" }}"/>
-      <cm:property name="error.backoff" value="{{ getv "/fits/redeliverybackoff" "1.0" }}"/>
+      <cm:property name="error.maxRedeliveries" value="{{ getv "/fits/redeliveries" (getenv "ALPACA_REDELIVERIES" "10") }}"/>
+      <cm:property name="error.redeliveryDelay" value="{{ getv "/fits/redeliverydelay" (getenv "ALPACA_REDELIVERYDELAY" "10000") }}"/>
+      <cm:property name="error.backoff" value="{{ getv "/fits/redeliverybackoff" (getenv "ALPACA_REDELIVERYBACKOFF" "1.0") }}"/>
+      <cm:property name="http.connectionRequestTimeoutMs" value="{{ getv "/fits/http/connection/request/timeout/ms" (getenv "ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000") }}"/>
+      <cm:property name="http.connectTimeoutMs" value="{{ getv "/fits/http/connect/timeout/ms" (getenv "ALPACA_HTTP_CONNECT_TIMEOUT_MS" "10000") }}"/>
+      <cm:property name="http.socketTimeoutMs" value="{{ getv "/fits/http/socket/timeout/ms" (getenv "ALPACA_HTTP_SOCKET_TIMEOUT_MS" "600000" ) }}"/>
       <cm:property name="in.stream" value="{{ getv "/fits/queue" "broker:queue:islandora-connector-fits" }}"/>
       <cm:property name="derivative.service.url" value="{{ getv "/fits/service" "http://crayfits:8000" }}"/>
 
@@ -55,9 +58,9 @@
   </bean>
 
   <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
-    <property name="connectionRequestTimeoutMs" value="{{ getenv "ALPACA_FITS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000" }}"/>
-    <property name="connectTimeoutMs" value="{{ getenv "ALPACA_FITS_HTTP_CONNECT_TIMEOUT_MS" "10000" }}"/>
-    <property name="socketTimeoutMs" value="{{ getenv "ALPACA_FITS_HTTP_SOCKET_TIMEOUT_MS" "600000" }}"/>
+    <property name="connectionRequestTimeoutMs" value="${http.connectionRequestTimeoutMs}"/>
+    <property name="connectTimeoutMs" value="${http.connectTimeoutMs}"/>
+    <property name="socketTimeoutMs" value="${http.socketTimeoutMs}"/>
   </bean>
 
   <bean id="http" class="org.apache.camel.component.http4.HttpComponent">

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.homarus.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.homarus.blueprint.xml.tmpl
@@ -10,9 +10,12 @@
 
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.homarus" update-strategy="reload" >
     <cm:default-properties>
-      <cm:property name="error.maxRedeliveries" value="{{ getv "/homarus/redeliveries" "10" }}"/>
-      <cm:property name="error.redeliveryDelay" value="{{ getv "/homarus/redeliverydelay" "10000" }}"/>
-      <cm:property name="error.backoff" value="{{ getv "/homarus/redeliverybackoff" "1.0" }}"/>
+      <cm:property name="error.maxRedeliveries" value="{{ getv "/homarus/redeliveries" (getenv "ALPACA_REDELIVERIES" "10") }}"/>
+      <cm:property name="error.redeliveryDelay" value="{{ getv "/homarus/redeliverydelay" (getenv "ALPACA_REDELIVERYDELAY" "10000") }}"/>
+      <cm:property name="error.backoff" value="{{ getv "/homarus/redeliverybackoff" (getenv "ALPACA_REDELIVERYBACKOFF" "1.0") }}"/>
+      <cm:property name="http.connectionRequestTimeoutMs" value="{{ getv "/homarus/http/connection/request/timeout/ms" (getenv "ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000") }}"/>
+      <cm:property name="http.connectTimeoutMs" value="{{ getv "/homarus/http/connect/timeout/ms" (getenv "ALPACA_HTTP_CONNECT_TIMEOUT_MS" "10000") }}"/>
+      <cm:property name="http.socketTimeoutMs" value="{{ getv "/homarus/http/socket/timeout/ms" (getenv "ALPACA_HTTP_SOCKET_TIMEOUT_MS" "600000" ) }}"/>
       <cm:property name="in.stream" value="{{ getv "/homarus/queue" "broker:queue:islandora-connector-homarus" }}"/>
       <cm:property name="derivative.service.url" value="{{ getv "/homarus/service" "http://homarus:8000/convert" }}"/>
 
@@ -54,9 +57,9 @@
   </bean>
 
   <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
-    <property name="connectionRequestTimeoutMs" value="{{ getenv "ALPACA_HOMERUS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000" }}"/>
-    <property name="connectTimeoutMs" value="{{ getenv "ALPACA_HOMERUS_HTTP_CONNECT_TIMEOUT_MS" "10000" }}"/>
-    <property name="socketTimeoutMs" value="{{ getenv "ALPACA_HOMERUS_HTTP_SOCKET_TIMEOUT_MS" "600000" }}"/>
+    <property name="connectionRequestTimeoutMs" value="${http.connectionRequestTimeoutMs}"/>
+    <property name="connectTimeoutMs" value="${http.connectTimeoutMs}"/>
+    <property name="socketTimeoutMs" value="${http.socketTimeoutMs}"/>
   </bean>
 
   <bean id="http" class="org.apache.camel.component.http4.HttpComponent">

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.houdini.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.houdini.blueprint.xml.tmpl
@@ -10,9 +10,12 @@
 
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.houdini" update-strategy="reload" >
     <cm:default-properties>
-      <cm:property name="error.maxRedeliveries" value="{{ getv "/houdini/redeliveries" "10" }}"/>
-      <cm:property name="error.redeliveryDelay" value="{{ getv "/houdini/redeliverydelay" "10000" }}"/>
-      <cm:property name="error.backoff" value="{{ getv "/houdini/redeliverybackoff" "1.0" }}"/>
+      <cm:property name="error.maxRedeliveries" value="{{ getv "/houdini/redeliveries" (getenv "ALPACA_REDELIVERIES" "10") }}"/>
+      <cm:property name="error.redeliveryDelay" value="{{ getv "/houdini/redeliverydelay" (getenv "ALPACA_REDELIVERYDELAY" "10000") }}"/>
+      <cm:property name="error.backoff" value="{{ getv "/houdini/redeliverybackoff" (getenv "ALPACA_REDELIVERYBACKOFF" "1.0") }}"/>
+      <cm:property name="http.connectionRequestTimeoutMs" value="{{ getv "/houdini/http/connection/request/timeout/ms" (getenv "ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000") }}"/>
+      <cm:property name="http.connectTimeoutMs" value="{{ getv "/houdini/http/connect/timeout/ms" (getenv "ALPACA_HTTP_CONNECT_TIMEOUT_MS" "10000") }}"/>
+      <cm:property name="http.socketTimeoutMs" value="{{ getv "/houdini/http/socket/timeout/ms" (getenv "ALPACA_HTTP_SOCKET_TIMEOUT_MS" "600000" ) }}"/>
       <cm:property name="in.stream" value="{{ getv "/houdini/queue" "broker:queue:islandora-connector-houdini" }}"/>
       <cm:property name="derivative.service.url" value="{{ getv "/houdini/service" "http://houdini:8000/convert" }}"/>
 
@@ -55,9 +58,9 @@
   </bean>
 
   <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
-    <property name="connectionRequestTimeoutMs" value="{{ getenv "ALPACA_HOUDINI_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000" }}"/>
-    <property name="connectTimeoutMs" value="{{ getenv "ALPACA_HOUDINI_HTTP_CONNECT_TIMEOUT_MS" "10000" }}"/>
-    <property name="socketTimeoutMs" value="{{ getenv "ALPACA_HOUDINI_HTTP_SOCKET_TIMEOUT_MS" "600000" }}"/>
+    <property name="connectionRequestTimeoutMs" value="${http.connectionRequestTimeoutMs}"/>
+    <property name="connectTimeoutMs" value="${http.connectTimeoutMs}"/>
+    <property name="socketTimeoutMs" value="${http.socketTimeoutMs}"/>
   </bean>
 
   <bean id="http" class="org.apache.camel.component.http4.HttpComponent">

--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.ocr.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.ocr.blueprint.xml.tmpl
@@ -10,9 +10,12 @@
 
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.ocr" update-strategy="reload" >
     <cm:default-properties>
-      <cm:property name="error.maxRedeliveries" value="{{ getv "/ocr/redeliveries" "10" }}"/>
-      <cm:property name="error.redeliveryDelay" value="{{ getv "/ocr/redeliverydelay" "10000" }}"/>
-      <cm:property name="error.backoff" value="{{ getv "/ocr/redeliverybackoff" "1.0" }}"/>
+      <cm:property name="error.maxRedeliveries" value="{{ getv "/ocr/redeliveries" (getenv "ALPACA_REDELIVERIES" "10") }}"/>
+      <cm:property name="error.redeliveryDelay" value="{{ getv "/ocr/redeliverydelay" (getenv "ALPACA_REDELIVERYDELAY" "10000") }}"/>
+      <cm:property name="error.backoff" value="{{ getv "/ocr/redeliverybackoff" (getenv "ALPACA_REDELIVERYBACKOFF" "1.0") }}"/>
+      <cm:property name="http.connectionRequestTimeoutMs" value="{{ getv "/ocr/http/connection/request/timeout/ms" (getenv "ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000") }}"/>
+      <cm:property name="http.connectTimeoutMs" value="{{ getv "/ocr/http/connect/timeout/ms" (getenv "ALPACA_HTTP_CONNECT_TIMEOUT_MS" "10000") }}"/>
+      <cm:property name="http.socketTimeoutMs" value="{{ getv "/ocr/http/socket/timeout/ms" (getenv "ALPACA_HTTP_SOCKET_TIMEOUT_MS" "600000" ) }}"/>
       <cm:property name="in.stream" value="{{ getv "/ocr/queue" "broker:queue:islandora-connector-ocr" }}"/>
       <cm:property name="derivative.service.url" value="{{ getv "/ocr/service" "http://hypercube:8000" }}"/>
 
@@ -55,9 +58,9 @@
   </bean>
 
   <bean id="requestConfigConfigurer" class="ca.islandora.alpaca.connector.derivative.RequestConfigConfigurer">
-    <property name="connectionRequestTimeoutMs" value="{{ getenv "ALPACA_OCR_HTTP_CONNECTION_REQUEST_TIMEOUT_MS" "10000" }}"/>
-    <property name="connectTimeoutMs" value="{{ getenv "ALPACA_OCR_HTTP_CONNECT_TIMEOUT_MS" "10000" }}"/>
-    <property name="socketTimeoutMs" value="{{ getenv "ALPACA_OCR_HTTP_SOCKET_TIMEOUT_MS" "600000" }}"/>
+    <property name="connectionRequestTimeoutMs" value="${http.connectionRequestTimeoutMs}"/>
+    <property name="connectTimeoutMs" value="${http.connectTimeoutMs}"/>
+    <property name="socketTimeoutMs" value="${http.socketTimeoutMs}"/>
   </bean>
 
   <bean id="http" class="org.apache.camel.component.http4.HttpComponent">


### PR DESCRIPTION
Introduce generic error redelivery and HTTP timeout parameters for Alpaca.

Introduces new general environment variables:
- `ALPACA_REDELIVERIES`
- `ALPACA_REDELIVERYDELAY`
- `ALPACA_REDELIVERYBACKOFF`
- `ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS`
- `ALPACA_HTTP_CONNECT_TIMEOUT_MS`
- `ALPACA_HTTP_SOCKET_TIMEOUT_MS`

These general environment variables may be overridden using their microservice equivalents, e.g.:
- `ALPACA_FITS_REDELIVERIES`
- `ALPACA_FITS_REDELIVERYDELAY`
- `ALPACA_FITS_REDELIVERYBACKOFF`
- `ALPACA_FITS_HTTP_CONNECTION_REQUEST_TIMEOUT_MS`
- `ALPACA_FITS_HTTP_CONNECT_TIMEOUT_MS`
- `ALPACA_FITS_SOCKET_TIMEOUT_MS`

This aligns the behavior (with respect to a general parameter and overriding them using microservice-specific equivalents) of these environment variables with the behavior of other parameters like those introduced by #53.

### To test
1. Build the alpaca image associated with this pr: `./gradlew -Plocal alpaca:build`
2. The general pattern is to start alpaca, set any environment variables, and view the blueprint xml files that are produced by `confd`.

View the baked-in default values, they should align with documented defaults.
```shell
docker run --rm \
  local/alpaca bash -lc \
  'for i in fits homarus houdini ocr ; do \
      echo ">>> deploy/ca.islandora.alpaca.connector.$i.blueprint.xml" ; \
      egrep \(name=\"http\\\..*\"\|name=\"error\\\..*\"\) deploy/ca.islandora.alpaca.connector.$i.blueprint.xml ; \
  done'
```

Set default values for all microservices; all microservices should share these values:
```shell
docker run --rm \
  -e ALPACA_REDELIVERIES=1234 \
  -e ALPACA_REDELIVERYDELAY=5678 \
  -e ALPACA_REDELIVERYBACKOFF=3.5 \
  -e ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS=2000 \
  -e ALPACA_HTTP_CONNECT_TIMEOUT_MS=5000 \
  -e ALPACA_HTTP_SOCKET_TIMEOUT_MS=9999 \
  local/alpaca bash -lc \
    'for i in fits homarus houdini ocr ; do \
      echo ">>> deploy/ca.islandora.alpaca.connector.$i.blueprint.xml" ; \
      egrep \(name=\"http\\\..*\"\|name=\"error\\\..*\"\) deploy/ca.islandora.alpaca.connector.$i.blueprint.xml ; \
    done'
```

Set the default values for all microservices, override the values for the FITS services:
```shell
docker run --rm \
  -e ALPACA_REDELIVERIES=1234 \
  -e ALPACA_REDELIVERYDELAY=5678 \
  -e ALPACA_REDELIVERYBACKOFF=3.5 \
  -e ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS=2000 \
  -e ALPACA_HTTP_CONNECT_TIMEOUT_MS=5000 \
  -e ALPACA_HTTP_SOCKET_TIMEOUT_MS=9999 \
  -e ALPACA_FITS_REDELIVERIES=91234 \
  -e ALPACA_FITS_REDELIVERYDELAY=95678 \
  -e ALPACA_FITS_REDELIVERYBACKOFF=93.5 \
  -e ALPACA_FITS_CONNECTION_REQUEST_TIMEOUT_MS=92000 \
  -e ALPACA_FITS_CONNECT_TIMEOUT_MS=95000 \
  -e ALPACA_FITS_SOCKET_TIMEOUT_MS=09999 \
  local/alpaca bash -lc \
    'for i in fits homarus houdini ocr ; do \
      echo ">>> deploy/ca.islandora.alpaca.connector.$i.blueprint.xml" ; \
      egrep \(name=\"http\\\..*\"\|name=\"error\\\..*\"\) deploy/ca.islandora.alpaca.connector.$i.blueprint.xml ; \
    done'
```

Override baked-in default values for the Houdini services:
```shell
docker run --rm \
  -e ALPACA_HOUDINI_REDELIVERIES=91234 \
  -e ALPACA_HOUDINI_REDELIVERYDELAY=95678 \
  -e ALPACA_HOUDINI_REDELIVERYBACKOFF=93.5 \
  -e ALPACA_HOUDINI_CONNECTION_REQUEST_TIMEOUT_MS=92000 \
  -e ALPACA_HOUDINI_CONNECT_TIMEOUT_MS=95000 \
  -e ALPACA_HOUDINI_SOCKET_TIMEOUT_MS=09999 \
  local/alpaca bash -lc \
    'for i in fits homarus houdini ocr ; do \
      echo ">>> deploy/ca.islandora.alpaca.connector.$i.blueprint.xml" ; \
      egrep \(name=\"http\\\..*\"\|name=\"error\\\..*\"\) deploy/ca.islandora.alpaca.connector.$i.blueprint.xml ; \
    done'
```