### PR TITLE
Add request and response nginx timeouts

### DIFF
--- a/drupal/README.md
+++ b/drupal/README.md
@@ -43,8 +43,10 @@ additional settings, volumes, ports, etc.
 | DRUPAL_DEFAULT_INSTALL          | /drupal/default/install          | true                    | Perform install if not already installed                  |
 | DRUPAL_FASTCGI_BUFFERS_NUMBER   | /drupal/fastcgi/buffers/number   | 8                       | nginx fastcgi_buffers number                              |
 | DRUPAL_FASTCGI_BUFFERS_SIZE     | /drupal/fastcgi/buffers/size     | 16k                     | nginx fastcgi_buffers size                                |
+| DRUPAL_FASTCGI_REQUEST_BUFFERING| /drupal/fastcgi/request/buffering| off                     | nginx fastcgi_request_buffering                           |
+| DRUPAL_FASTCGI_READ_TIMEOUT     | /drupal/fastcgi/read/timeout     | 300s                    | nginx fastcgi_read_timeout                                |
+| DRUPAL_FASTCGI_SEND_TIMEOUT     | /drupal/fastcgi/send/timeout     | 300s                    | nginx fastcgi_send_timeout                                |
 | DRUPAL_FASTCGI_BUFFER_SIZE      | /drupal/fastcgi/buffer/size      | 32k                     | nginx fastcgi_buffer size                                 |
-
 
 Additional multi-sites can be defined by adding more environment variables,
 following the above conventions, only the `DRUPAL_SITE_{SITE}_NAME` is required

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -43,7 +43,6 @@ additional settings, volumes, ports, etc.
 | DRUPAL_DEFAULT_INSTALL          | /drupal/default/install          | true                    | Perform install if not already installed                  |
 | DRUPAL_FASTCGI_BUFFERS_NUMBER   | /drupal/fastcgi/buffers/number   | 8                       | nginx fastcgi_buffers number                              |
 | DRUPAL_FASTCGI_BUFFERS_SIZE     | /drupal/fastcgi/buffers/size     | 16k                     | nginx fastcgi_buffers size                                |
-| DRUPAL_FASTCGI_REQUEST_BUFFERING| /drupal/fastcgi/request/buffering| off                     | nginx fastcgi_request_buffering                           |
 | DRUPAL_FASTCGI_READ_TIMEOUT     | /drupal/fastcgi/read/timeout     | 300s                    | nginx fastcgi_read_timeout                                |
 | DRUPAL_FASTCGI_SEND_TIMEOUT     | /drupal/fastcgi/send/timeout     | 300s                    | nginx fastcgi_send_timeout                                |
 | DRUPAL_FASTCGI_BUFFER_SIZE      | /drupal/fastcgi/buffer/size      | 32k                     | nginx fastcgi_buffer size                                 |

--- a/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
+++ b/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
@@ -119,7 +119,6 @@ server {
 
         fastcgi_send_timeout  {{getv "/fastcgi/send/timeout" "300s"}};
         fastcgi_read_timeout  {{getv "/fastcgi/read/timeout" "300s"}};
-        fastcgi_request_buffering  {{getv "/fastcgi/request/buffering" "on"}};
     }
 
     # Fighting with Styles? This little gem is amazing.

--- a/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
+++ b/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
@@ -116,6 +116,10 @@ server {
         # linked entities are added to Drupal metadata
         fastcgi_buffers {{getv "/fastcgi/buffers/number" "8"}}  {{getv "/fastcgi/buffers/size" "16k"}};
         fastcgi_buffer_size  {{getv "/fastcgi/buffer/size" "32k"}};
+
+        fastcgi_send_timeout  {{getv "/fastcgi/send/timeout" "300s"}};
+        fastcgi_read_timeout  {{getv "/fastcgi/read/timeout" "300s"}};
+        fastcgi_request_buffering  {{getv "/fastcgi/request/buffering" "off"}};
     }
 
     # Fighting with Styles? This little gem is amazing.

--- a/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
+++ b/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
@@ -119,7 +119,7 @@ server {
 
         fastcgi_send_timeout  {{getv "/fastcgi/send/timeout" "300s"}};
         fastcgi_read_timeout  {{getv "/fastcgi/read/timeout" "300s"}};
-        fastcgi_request_buffering  {{getv "/fastcgi/request/buffering" "off"}};
+        fastcgi_request_buffering  {{getv "/fastcgi/request/buffering" "on"}};
     }
 
     # Fighting with Styles? This little gem is amazing.


### PR DESCRIPTION
Resolves  jhu-idc/idc-general#369

Adds and documents `DRUPAL_FASTCGI_SEND_TIMEOUT` and `DRUPAL_FASTCGI_READ_TIMEOUT`, `DRUPAL_FASTCGI_REQUEST_BUFFERING` environment variables, set to reasonable defaults that seem to work for Michelle's ingest use case.  

From ops side, no new environment variables _need_ to be set, unless we discover the defaults in this PR aren't adequate, and need tweaking

