### PR TITLE
Increase timeout for gh actions execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: Build and Push Buildkit Docker Images
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     outputs:
       image-tag: ${{ steps.output-image-tag.outputs.image-tag }}
     defaults:
@@ -50,7 +50,7 @@ jobs:
     name: Run idc-isle-dc Tests
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     defaults:
       run:
         working-directory: isle-dc

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_test:
     name: Build Docker Images and Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     outputs:
       image-tag: ${{ steps.output-image-tag.outputs.image-tag }}
     defaults:


### PR DESCRIPTION
We really need a better solution, but this bumps execution time to _two hours_