### PR TITLE
Support PHP_MAX_EXECUTION_TIME for the drupal image.

### DIFF
--- a/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
+++ b/drupal/rootfs/etc/confd/templates/nginx_default.conf.tmpl
@@ -109,6 +109,7 @@ server {
         fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_param QUERY_STRING $query_string;
         fastcgi_intercept_errors on;
+        fastcgi_read_timeout {{ getenv "PHP_MAX_EXECUTION_TIME" "60" }};
         # PHP 7 socket location.
         fastcgi_pass unix:/var/run/php-fpm7/php-fpm7.sock;
 


### PR DESCRIPTION
Migrations that use the new migration implementation introduced by [pr/183](https://github.com/jhu-idc/idc-isle-dc/pull/183) may extend beyond the `PHP_MAX_EXECUTION_TIME`.

This updates the Drupal container to use the `PHP_MAX_EXECUTION_TIME` from the environment.