### PR TITLE
Configure sendmail wrapper using confd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,12 +90,17 @@ jobs:
         run: ./gradlew --console plain -PregistryUrl=${{ secrets.REGISTRY_URL }} -PregistryUsername=${{ secrets.REGISTRY_USER }} -PregistryPassword=${{ secrets.REGISTRY_PASS }} -Prepository=${{ secrets.REPOSITORY }} ${{ matrix.image-name }}:push
       - name: Label Image
         run: |
+          if [ "${{github.event_name}}" == "pull_request" ] ; then
+            export IMAGE_DESC="IDC ${{matrix.image-name}} image (via idc-isle-buildkit PR head ${{ github.event.pull_request.head.sha }}, base ${{ github.event.pull_request.base.sha }}, merge ${{ github.sha }})"
+          else
+            export IMAGE_DESC="IDC ${{matrix.image-name}} image (via idc-isle-buildkit commit ${{ github.sha }})"
+          fi
           echo "FROM ${{ secrets.REPOSITORY }}/${{matrix.image-name}}:${{needs.setup.outputs.image-tag}}" | \
           docker build -t ${{ secrets.REPOSITORY }}/${{matrix.image-name}}:${{needs.setup.outputs.image-tag}} \
             --label org.opencontainers.image.title="idc-isle-buildkit ${{matrix.image-name}}"\
-            --label org.opencontainers.image.description="IDC ${{matrix.image-name}} image" \
-            --label org.opencontainers.image.url=${{github.event.repository.url}}/tree/${{github.event.repository.default_branch}}/${{matrix.image-name}} \
-            --label org.opencontainers.image.source=${{github.event.repository.url}} \
+            --label org.opencontainers.image.description="${IMAGE_DESC}" \
+            --label org.opencontainers.image.url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/${{github.event.repository.default_branch}}/${{matrix.image-name}} \
+            --label org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
             --label org.opencontainers.image.version=${{needs.setup.outputs.image-tag}} \
             --label org.opencontainers.image.created=${{needs.setup.outputs.build-date}} \
             --label org.opencontainers.image.revision=${{github.sha}} \
@@ -133,32 +138,29 @@ jobs:
         run: docker-compose exec -T drupal drush -d status
       - name: Label static image
         run: |
-          export CI_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          echo "Using CI_URL: ${CI_URL}"
           if [ "${{github.event_name}}" == "pull_request" ] ; then
-            export IMAGE_DESC="IDC drupal-static image (via idc-isle-buildkit PR ${{ github.head_ref }})"
+            export IMAGE_DESC="IDC drupal-static image (via idc-isle-buildkit PR head ${{ github.event.pull_request.head.sha }}, base ${{ github.event.pull_request.base.sha }}, merge ${{ github.sha }})"
           else
-            export IMAGE_DESC="IDC drupal-static image (via idc-isle-buildkit ${{ github.sha }})"
+            export IMAGE_DESC="IDC drupal-static image (via idc-isle-buildkit commit ${{ github.sha }})"
           fi
-          echo "Using IMAGE_DESC: ${IMAGE_DESC}"
           export STATIC_TAG=$(docker images | grep ${{ secrets.REPOSITORY }}/drupal-static | awk '{print $2}')
           echo "FROM ${{ secrets.REPOSITORY }}/drupal-static:${STATIC_TAG}" | \
-          docker build -t ${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}} \
+          docker build -t ${{ secrets.REPOSITORY }}/drupal-static:${{needs.setup.outputs.image-tag}} \
             --label org.opencontainers.image.title="idc-isle-buildkit drupal-static" \
             --label org.opencontainers.image.description="${IMAGE_DESC}" \
-            --label org.opencontainers.image.url=${{github.event.repository.url}}/tree/${{github.event.repository.default_branch}}/drupal \
+            --label org.opencontainers.image.url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/${{github.event.repository.default_branch}}/drupal \
             --label org.opencontainers.image.source="$(git remote get-url origin)" \
-            --label org.opencontainers.image.version=${{needs.build.outputs.image-tag}} \
+            --label org.opencontainers.image.version=${{needs.setup.outputs.image-tag}} \
             --label org.opencontainers.image.created="$(date)" \
             --label org.opencontainers.image.revision="$(git log -1 --format='%h')" \
             --label org.opencontainers.image.licenses=MIT \
-            --label org.opencontainers.image.ref.name=${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}} \
-            --label ci.url="${CI_URL}" \
+            --label org.opencontainers.image.ref.name=${{ secrets.REPOSITORY }}/drupal-static:${{needs.setup.outputs.image-tag}} \
+            --label ci.url="${{needs.setup.outputs.ci-url}}" \
             -
       - name: Push static image
         run: |
           docker login -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASS }}' '${{ secrets.REGISTRY_URL }}'
-          docker push ${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}}
+          docker push ${{ secrets.REPOSITORY }}/drupal-static:${{needs.setup.outputs.image-tag}}
   test-matrix:
     name: Generate idc-isle-dc test matrix
     needs: setup
@@ -205,9 +207,9 @@ jobs:
           grep TAG .env
       - name: Use Static Drupal Image
         run: |
-          echo "Pulling static image ${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}}"
+          echo "Pulling static image ${{ secrets.REPOSITORY }}/drupal-static:${{needs.setup.outputs.image-tag}}"
           docker login -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASS }}' '${{ secrets.REGISTRY_URL }}' && \
-          docker pull ${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}} && \
+          docker pull ${{ secrets.REPOSITORY }}/drupal-static:${{needs.setup.outputs.image-tag}} && \
           make static-docker-compose.yml
       - name: Run ${{ matrix.test }}
         run: make up test test=${{ matrix.test }}
@@ -223,3 +225,38 @@ jobs:
         with:
           name: reports-${{matrix.test}}
           path: end-to-end/reports
+  image-locations:
+    name: Comment with image locations
+    if: ${{github.event_name}} == "pull_request"
+    runs-on: ubuntu-latest
+    needs: [ build, static, test-matrix, setup, test ]
+    steps:
+      - name: Generate idc-isle-dc commit url
+        id: isledc-commit-url
+        run: echo "::set-output name=isledc-commit-url::$GITHUB_SERVER_URL/jhu-idc/idc-isle-dc/tree/${{needs.setup.outputs.isledc-commit}}"
+      - name: Create comment with image tags
+        run: |
+          cat << 'EOF' > image.md
+          #### Images for idc-isle-buildkit commit `${{github.event.pull_request.head.sha}}`
+          * Buildkit images were built from idc-isle-buildkit head `${{github.head_ref}}` (`${{github.event.pull_request.head.sha}}`)
+            * Base ref: `${{github.base_ref}}` (`${{github.event.pull_request.base.sha}}`)
+            * Merge ref: `${{github.sha}}`
+          * All images have been pushed to `${{ secrets.REPOSITORY }}` with tag `${{needs.setup.outputs.image-tag}}`
+          * `drupal-static` was built from [idc-isle-dc commit `${{needs.setup.outputs.isledc-commit}}`](${{steps.isledc-commit-url.outputs.isledc-commit-url}})
+          * Workflow logs for these images may be viewed [here](${{needs.setup.outputs.ci-url}})
+
+          Example docker pull command:
+          ```
+          docker pull ${{ secrets.REPOSITORY }}/drupal-static:${{needs.setup.outputs.image-tag}}
+          ```
+          EOF
+      - name: Add failure warning
+        if: failure()
+        run: |
+          echo -e "> **Warning**: idc-isle-dc [tests failed](${{needs.setup.outputs.ci-url}}), so the images may not be useful for testing.\n\n$(cat image.md)" > image.md
+      - name: Post comment
+        uses: machine-learning-apps/pr-comment@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: image.md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
           docker login -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASS }}' '${{ secrets.REGISTRY_URL }}'
           docker push ${{ secrets.REPOSITORY }}/${{matrix.image-name}}:${{needs.setup.outputs.image-tag}}
   static:
-    name: Create Drupal Static Image
+    name: Create and Push Drupal Static Image
     needs: [ setup, build ]
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -131,12 +131,34 @@ jobs:
         run: make static-docker-compose.yml up
       - name: Drush test
         run: docker-compose exec -T drupal drush -d status
-      - name: Export image
-        run: make static-drupal-image-export
-      - uses: actions/upload-artifact@v2
-        with:
-          name: drupal-image
-          path: isle-dc/images
+      - name: Label static image
+        run: |
+          export CI_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo "Using CI_URL: ${CI_URL}"
+          if [ "${{github.event_name}}" == "pull_request" ] ; then
+            export IMAGE_DESC="IDC drupal-static image (via idc-isle-buildkit PR ${{ github.head_ref }})"
+          else
+            export IMAGE_DESC="IDC drupal-static image (via idc-isle-buildkit ${{ github.sha }})"
+          fi
+          echo "Using IMAGE_DESC: ${IMAGE_DESC}"
+          export STATIC_TAG=$(docker images | grep ${{ secrets.REPOSITORY }}/drupal-static | awk '{print $2}')
+          echo "FROM ${{ secrets.REPOSITORY }}/drupal-static:${STATIC_TAG}" | \
+          docker build -t ${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}} \
+            --label org.opencontainers.image.title="idc-isle-buildkit drupal-static" \
+            --label org.opencontainers.image.description="${IMAGE_DESC}" \
+            --label org.opencontainers.image.url=${{github.event.repository.url}}/tree/${{github.event.repository.default_branch}}/drupal \
+            --label org.opencontainers.image.source="$(git remote get-url origin)" \
+            --label org.opencontainers.image.version=${{needs.build.outputs.image-tag}} \
+            --label org.opencontainers.image.created="$(date)" \
+            --label org.opencontainers.image.revision="$(git log -1 --format='%h')" \
+            --label org.opencontainers.image.licenses=MIT \
+            --label org.opencontainers.image.ref.name=${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}} \
+            --label ci.url="${CI_URL}" \
+            -
+      - name: Push static image
+        run: |
+          docker login -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASS }}' '${{ secrets.REGISTRY_URL }}'
+          docker push ${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}}
   test-matrix:
     name: Generate idc-isle-dc test matrix
     needs: setup
@@ -181,13 +203,12 @@ jobs:
           echo "Using image tag ${{needs.setup.outputs.image-tag}}"
           sed -i.bak -e 's@^TAG.*$@TAG=${{needs.setup.outputs.image-tag}}@' .env
           grep TAG .env
-      - name: Download Drupal Image
-        uses: actions/download-artifact@v2
-        with:
-          name: drupal-image
-          path: images
-      - name: Load Drupal Image
-        run: docker load < images/static-drupal.tar
+      - name: Use Static Drupal Image
+        run: |
+          echo "Pulling static image ${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}}"
+          docker login -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASS }}' '${{ secrets.REGISTRY_URL }}' && \
+          docker pull ${{ secrets.REPOSITORY }}/drupal-static:${{needs.build.outputs.image-tag}} && \
+          make static-docker-compose.yml
       - name: Run ${{ matrix.test }}
         run: make up test test=${{ matrix.test }}
       - name: Capture Logs

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -66,4 +66,31 @@ to create an additional site:
 | DRUPAL_SITE_{SITE}_CONFIGDIR        | /drupal/site/{SITE}/configdir        |                         | Install using existing config files from directory |
 | DRUPAL_SITE_{SITE}_INSTALL          | /drupal/site/{SITE}/install          | true                    | Perform install if not already installed           |
 
+## Configuring SMTP
+Drupal must have the following environment variables preset at runtime in order to send email through an SMTP relay.  These variables configure PHP-related SMTP settings in `php.ini` (which is parameterized by `confd`).  The only dependency is on the OpenSSL binary, which must be present in the command path (it is, by default).
+
+Busybox sendmail is configured by default, and existing settings have been tested with GMail SMTP.  For example, to use GMail's SMTP relays, you would use the following values:
+* `DRUPAL_SMTP_ENABLE`: `true`
+* `DRUPAL_SMTP_AUTH_PRINCIPAL`: `<user>@gmail.com`
+* `DRUPAL_SMTP_AUTH_TOKEN`: `<gmail app token>`
+* `DRUPAL_SMTP_FROM_ADDRESS`: `webmaster@library.jhu.edu`
+* `DRUPAL_SMTP_RELAY_HOST`: `smtp.gmail.com`
+
+The default values for the remaining required variables suffice.
+
+## SMTP Environment Variables
+
+|Environment Variable        |Default Value                         |Description|
+|----------------------------|--------------------------------------|--------------------------------------|
+|`DRUPAL_SMTP_ENABLE`        |`` (the zero-length string)           |Determines whether SMTP is enabled or not.  Any non-empty value (e.g. `true`) may be used.  If the value is the zero-length string, none of the SMTP-related variables have affect| 
+|`DRUPAL_SMTP_VERBOSE`       |`` (the zero-length string)           |Logs entire SMTP exchanges with the relay.  Any non-empty value (e.g. `true`) may be used.  Useful for debugging but does echo sensitive information to the logs.|
+|`DRUPAL_SMTP_MSA_BIN`       |`sendmail`                            |(required) Path to Sendmail. By default the BusyBox sendmail wrapper is used.|
+|`DRUPAL_SMTP_AUTH_MECH`     |`LOGIN`                               |(required) The SMTP auth mechanism used.  Exactly one authentication mechanism must be defined.|
+|`DRUPAL_SMTP_AUTH_PRINCIPAL`|-                                     |(required) The SMTP user principal to authenticate as.  Since there is no default provided, this _must_ be defined.|
+|`DRUPAL_SMTP_AUTH_TOKEN`    |-                                     |(required) The SMTP authentication token to authenticate with.  Since there is no default provided, this _must_ be defined.
+|`DRUPAL_SMTP_FROM_ADDRESS`  |-                                     |(required) A trusted from address used by `MAIL FROM`.  Since there is no default provided, this _must_ be defined.|
+|`DRUPAL_SMTP_RELAY_HOST`    |`email-smtp.us-east-1.amazonaws.com`  |(required) The IP address or DNS name of the SMTP relay to use.|
+|`DRUPAL_SMTP_RELAY_PORT`    |`587`                                 |(required) The Mail Submission Port used by the SMTP relay.|
+|`DRUPAL_SMTP_TLS_VERSION`   |`tls1_3`                              |(required) The TLS version to use.  Valid values are determined by the OpenSSL library.  Example valid values are: `tls1`, `tls1_1`, `tls1_2`, `tls1_3`.
+
 [Drupal]: https://www.drupal.org/

--- a/nginx/rootfs/etc/confd/templates/php.ini.tmpl
+++ b/nginx/rootfs/etc/confd/templates/php.ini.tmpl
@@ -1070,7 +1070,15 @@ smtp_port = 25
 
 ; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
 ; http://php.net/sendmail-path
+{{ if getenv "DRUPAL_SMTP_ENABLE" "" }}
+{{ if getenv "DRUPAL_SMTP_VERBOSE" "" }}
+sendmail_path = "{{ getenv "DRUPAL_SMTP_MSA_BIN" "sendmail" }} -v -t -am{{ getenv "DRUPAL_SMTP_AUTH_MECH" "LOGIN" }} -au{{ getenv "DRUPAL_SMTP_AUTH_PRINCIPAL" }} -ap{{ getenv "DRUPAL_SMTP_AUTH_TOKEN" }} -f {{ getenv "DRUPAL_SMTP_FROM_ADDRESS" }} -H 'openssl s_client -quiet -{{ getenv "DRUPAL_SMTP_TLS_VERSION" "tls1_2" }} -starttls smtp -connect {{ getenv "DRUPAL_SMTP_RELAY_HOST" "email-smtp.us-east-1.amazonaws.com" }}:{{ getenv "DRUPAL_SMTP_RELAY_PORT" "587" }}'"
+{{ else }}
+sendmail_path = "{{ getenv "DRUPAL_SMTP_MSA_BIN" "sendmail" }}    -t -am{{ getenv "DRUPAL_SMTP_AUTH_MECH" "LOGIN" }} -au{{ getenv "DRUPAL_SMTP_AUTH_PRINCIPAL" }} -ap{{ getenv "DRUPAL_SMTP_AUTH_TOKEN" }} -f {{ getenv "DRUPAL_SMTP_FROM_ADDRESS" }} -H 'openssl s_client -quiet -{{ getenv "DRUPAL_SMTP_TLS_VERSION" "tls1_2" }} -starttls smtp -connect {{ getenv "DRUPAL_SMTP_RELAY_HOST" "email-smtp.us-east-1.amazonaws.com" }}:{{ getenv "DRUPAL_SMTP_RELAY_PORT" "587" }}'"
+{{ end }}
+{{ else }}
 ;sendmail_path =
+{{ end }}
 
 ; Force the addition of the specified parameters to be passed as extra parameters
 ; to the sendmail binary. These parameters will always replace the value of

--- a/nginx/rootfs/etc/confd/templates/php.ini.tmpl
+++ b/nginx/rootfs/etc/confd/templates/php.ini.tmpl
@@ -1072,9 +1072,9 @@ smtp_port = 25
 ; http://php.net/sendmail-path
 {{ if getenv "DRUPAL_SMTP_ENABLE" "" }}
 {{ if getenv "DRUPAL_SMTP_VERBOSE" "" }}
-sendmail_path = "{{ getenv "DRUPAL_SMTP_MSA_BIN" "sendmail" }} -v -t -am{{ getenv "DRUPAL_SMTP_AUTH_MECH" "LOGIN" }} -au{{ getenv "DRUPAL_SMTP_AUTH_PRINCIPAL" }} -ap{{ getenv "DRUPAL_SMTP_AUTH_TOKEN" }} -f {{ getenv "DRUPAL_SMTP_FROM_ADDRESS" }} -H 'openssl s_client -quiet -{{ getenv "DRUPAL_SMTP_TLS_VERSION" "tls1_2" }} -starttls smtp -connect {{ getenv "DRUPAL_SMTP_RELAY_HOST" "email-smtp.us-east-1.amazonaws.com" }}:{{ getenv "DRUPAL_SMTP_RELAY_PORT" "587" }}'"
+sendmail_path = "{{ getenv "DRUPAL_SMTP_MSA_BIN" "sendmail" }} -v -t -am{{ getenv "DRUPAL_SMTP_AUTH_MECH" "LOGIN" }} -au{{ getenv "DRUPAL_SMTP_AUTH_PRINCIPAL" }} -ap{{ getenv "DRUPAL_SMTP_AUTH_TOKEN" }} -f {{ getenv "DRUPAL_SMTP_FROM_ADDRESS" }} -H 'openssl s_client -quiet -{{ getenv "DRUPAL_SMTP_TLS_VERSION" "tls1_3" }} -starttls smtp -connect {{ getenv "DRUPAL_SMTP_RELAY_HOST" "email-smtp.us-east-1.amazonaws.com" }}:{{ getenv "DRUPAL_SMTP_RELAY_PORT" "587" }}'"
 {{ else }}
-sendmail_path = "{{ getenv "DRUPAL_SMTP_MSA_BIN" "sendmail" }}    -t -am{{ getenv "DRUPAL_SMTP_AUTH_MECH" "LOGIN" }} -au{{ getenv "DRUPAL_SMTP_AUTH_PRINCIPAL" }} -ap{{ getenv "DRUPAL_SMTP_AUTH_TOKEN" }} -f {{ getenv "DRUPAL_SMTP_FROM_ADDRESS" }} -H 'openssl s_client -quiet -{{ getenv "DRUPAL_SMTP_TLS_VERSION" "tls1_2" }} -starttls smtp -connect {{ getenv "DRUPAL_SMTP_RELAY_HOST" "email-smtp.us-east-1.amazonaws.com" }}:{{ getenv "DRUPAL_SMTP_RELAY_PORT" "587" }}'"
+sendmail_path = "{{ getenv "DRUPAL_SMTP_MSA_BIN" "sendmail" }}    -t -am{{ getenv "DRUPAL_SMTP_AUTH_MECH" "LOGIN" }} -au{{ getenv "DRUPAL_SMTP_AUTH_PRINCIPAL" }} -ap{{ getenv "DRUPAL_SMTP_AUTH_TOKEN" }} -f {{ getenv "DRUPAL_SMTP_FROM_ADDRESS" }} -H 'openssl s_client -quiet -{{ getenv "DRUPAL_SMTP_TLS_VERSION" "tls1_3" }} -starttls smtp -connect {{ getenv "DRUPAL_SMTP_RELAY_HOST" "email-smtp.us-east-1.amazonaws.com" }}:{{ getenv "DRUPAL_SMTP_RELAY_PORT" "587" }}'"
 {{ end }}
 {{ else }}
 ;sendmail_path =


### PR DESCRIPTION
## Testing
Unfortunately, you cannot easily run the drupal image in isolation because `confd` errors out when certain environment variables are missing.  I don't know what they are, and it's a potentially long list.  The easiest thing to do will be to build this image and launch the stack, then review the `php.ini` file in `/etc/php7/php.ini`.

1. Up-to-date image tags (including `drupal-static`) for this PR are found in the last comment from the `github-actions` bot.  (Each time this PR is amended, new images are pushed, and a comment is appended to the PR with their tag).
2. Check out the tip of `development` from [`idc-isle-dc`](https://github.com/jhu-idc/idc-isle-dc)
3. Configure idc-isle-dc to use the most recent drupal image from this PR by editing `idc-isle-dc/docker-compose.local.yml` and change the line `image: ${REPOSITORY:-islandora}/drupal:${TAG:-latest}` to point to the latest static image derived from step 1, e.g.: `ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal-static:upstream-20200824-f8d1e8e-48-gc66de6c`
4. Add the SMTP configuration environment variables to `idc-isle-dc/docker-compose.env.yml`.  Locate the drupal environment keys, and add all required keys that _have no default_, along with any other keys you wish to override, e.g.:
```
      DRUPAL_SMTP_ENABLE: "true"
      DRUPAL_SMTP_AUTH_PRINCIPAL: "foo@bar.com"
      DRUPAL_SMTP_AUTH_TOKEN: "token xyz"
      DRUPAL_SMTP_FROM_ADDRESS: "webmaster@library.jhu.edu"
      DRUPAL_SMTP_RELAY_HOST: "smtp.gmail.com"
      DRUPAL_SMTP_VERBOSE: "true"
```
5. Re-generate `idc-isle-dc/docker-compose.yml`: `make -B docker-compose.yml`
6. Start the stack by invoking `make up` inside idc-isle-dc.

Once Drupal has started, you can examine the contents of `/etc/php7/php.ini`.  The easiest thing to do is run: `docker-compose exec drupal egrep '^sendmail' /etc/php7/php.ini`.  You should see output similar to (asterisks are redactions by me).  The values you see in the `php.ini` file ought to align with the values you have provided .
```
sendmail_path = "sendmail -v -t -amLOGIN -au***@gmail.com -ap***** -f webmaster@library.jhu.edu -H 'openssl s_client -quiet -tls1_2 -starttls smtp -connect smtp.gmail.com:587'"
```

After getting this far, the next step is to send email.  Since this PR deals with low-level SMTP plumbing, and since we'll ultimately be using PHP to send emails, the easiest thing to do is use the PHP `mail()` function.
1. Obtain an interactive PHP shell in the drupal container: `docker-compose exec drupal php -a -c /etc/php7/php.ini`
2. Send a message by invoking `mail('validemailaddress@example.com', 'Test Subject', 'Test Message Body');`
3. Observe the output in the drupal log (e.g. in another terminal run `docker-compose logs -f drupal`) and make sure you don't see obvious errors in the SMTP exchange
4. Check for the test email send to 'validemailaddress@example.com'.

Read on for more explanation of SMTP configuration and the environment variables involved.
 
## Configuring SMTP
Drupal must have the following environment variables preset at runtime in order to send email through an SMTP relay.  These variables configure PHP-related SMTP settings in `php.ini` (which is parameterized by `confd`).  The only dependency is on the OpenSSL binary, which must be present in the command path (it is, by default).

Busybox sendmail is configured by default, and existing settings have been tested with GMail SMTP.  For example, to use GMail's SMTP relays, you would use the following values:
* `DRUPAL_SMTP_ENABLE`: `true`
* `DRUPAL_SMTP_AUTH_PRINCIPAL`: `<user>@gmail.com`
* `DRUPAL_SMTP_AUTH_TOKEN`: `<gmail app token>`
* `DRUPAL_SMTP_FROM_ADDRESS`: `webmaster@library.jhu.edu`
* `DRUPAL_SMTP_RELAY_HOST`: `smtp.gmail.com`

The default values for the remaining required variables suffice.

## SMTP Environment Variables

|Environment Variable        |Default Value                         |Description|
|----------------------------|--------------------------------------|--------------------------------------|
|`DRUPAL_SMTP_ENABLE`        |`` (the zero-length string)           |Determines whether SMTP is enabled or not.  Any non-empty value (e.g. `true`) may be used.  If the value is the zero-length string, none of the SMTP-related variables have affect| 
|`DRUPAL_SMTP_VERBOSE`       |`` (the zero-length string)           |Logs entire SMTP exchanges with the relay.  Any non-empty value (e.g. `true`) may be used.  Useful for debugging but does echo sensitive information to the logs.|
|`DRUPAL_SMTP_MSA_BIN`       |`sendmail`                            |(required) Path to Sendmail. By default the BusyBox sendmail wrapper is used.|
|`DRUPAL_SMTP_AUTH_MECH`     |`LOGIN`                               |(required) The SMTP auth mechanism used.  Exactly one authentication mechanism must be defined.|
|`DRUPAL_SMTP_AUTH_PRINCIPAL`|-                                     |(required) The SMTP user principal to authenticate as.  Since there is no default provided, this _must_ be defined.|
|`DRUPAL_SMTP_AUTH_TOKEN`    |-                                     |(required) The SMTP authentication token to authenticate with.  Since there is no default provided, this _must_ be defined.
|`DRUPAL_SMTP_FROM_ADDRESS`  |-                                     |(required) A trusted from address used by `MAIL FROM`.  Since there is no default provided, this _must_ be defined.|
|`DRUPAL_SMTP_RELAY_HOST`    |`email-smtp.us-east-1.amazonaws.com`  |(required) The IP address or DNS name of the SMTP relay to use.|
|`DRUPAL_SMTP_RELAY_PORT`    |`587`                                 |(required) The Mail Submission Port used by the SMTP relay.|
|`DRUPAL_SMTP_TLS_VERSION`   |`tls1_3`                              |(required) The TLS version to use.  Valid values are determined by the OpenSSL library.  Example valid values are: `tls1`, `tls1_1`, `tls1_2`, `tls1_3`.

## New CI behavior
This PR contains a modification to the CI, whereby a static image is pushed and a comment is appended to the PR with the tag and an example `docker pull` command.  After this PR is merged, all PRs to `idc-isle-buildkit` and all pushes to the `main` branch will push a `drupal-static` image.