### PR TITLE
Only attempt to change ownership if settings.php isn't writable.

### DIFF
--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -312,7 +312,7 @@ function update_settings_php {
     fi
 
     # Allow modifications to settings.php
-    if [ -f "${site_directory}/settings.php" ]; then
+    if [ -f "${site_directory}/settings.php" ] && [ ! -w "${site_directory}/settings.php" ]; then
         previous_owner_group=$(stat -c "%u:%g" "${site_directory}/settings.php")
         chown 100:101 "${site_directory}/settings.php"
         chmod a=rwx "${site_directory}/settings.php"


### PR DESCRIPTION
On my Mac platform, the `chown` command in `drupal/rootfs/etc/islandora/utilities.sh` (line 316) fails inexplicably.  I'm not sure what's up, but I also experience file permission related errors when `make reset` is performed and the harding module attempts to remove files under `codebase/`.  So there may be a more general issue with Docker for Mac on my platform regarding file ownership.

The issue with `chown` [prevents me](https://gist.github.com/emetsger/910589dac4bb02dac01721db2f668dc3) from running the [validation test suite with `CI=true`](https://github.com/jhu-idc/idc-isle-dc/pull/193).

At any rate, the `chown`/`chmod` is an attempt to make `settings.php` writable for the successive drush commands, but on my platform the `chown` is not required; `settings.php` is by default `644`.  

This PR insures the `chown` is necessary by checking the file for writability before resorting to `chown`.  On my platform, this leads to successful execution of the [validation test suite with `CI=true`](https://github.com/jhu-idc/idc-isle-dc/pull/193) by bypassing an unnecessary call to `chown`.