### PR TITLE
Fix php internationalization

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,30 +6,32 @@ RUN --mount=type=cache,target=/var/cache/apk \
     apk-install.sh \
         composer \
         nginx \
+        php7 \
         php7-ctype \
         php7-curl \
         php7-dom \
         php7-fileinfo \
         php7-fpm \
         php7-gd \
-        php7-opcache \
-        php7-pdo \
-        php7-pdo_mysql \ 
-        php7-pdo_pgsql \ 
+        php7-iconv \
+        php7-intl \
+        php7-json \
+        php7-mbstring \
         php7-mysqli \
+        php7-opcache \
+        php7-openssl \
+        php7-pdo \
+        php7-pdo_mysql \
+        php7-pdo_pgsql \
+        php7-phar \
         php7-session \
         php7-simplexml \
         php7-tokenizer \
         php7-xml \
         php7-xmlwriter \
+        php7-xmlreader \
         php7-xsl \
-        php7-fileinfo \
-        php7-pdo_sqlite \
-        php7-ldap \
-        php7-mbstring \
-        php7-sqlite3 \
         php7-zip \
-        php7-yaml \
     && \
     cleanup.sh
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -16,6 +16,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
         php7-iconv \
         php7-intl \
         php7-json \
+        php7-ldap \
         php7-mbstring \
         php7-mysqli \
         php7-opcache \
@@ -23,14 +24,17 @@ RUN --mount=type=cache,target=/var/cache/apk \
         php7-pdo \
         php7-pdo_mysql \
         php7-pdo_pgsql \
+        php7-pdo_sqlite \
         php7-phar \
         php7-session \
         php7-simplexml \
+        php7-sqlite3 \
         php7-tokenizer \
         php7-xml \
         php7-xmlwriter \
         php7-xmlreader \
         php7-xsl \
+        php7-yaml \
         php7-zip \
     && \
     cleanup.sh

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,6 +6,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
     apk-install.sh \
         composer \
         nginx \
+        gnu-libiconv \
         php7 \
         php7-ctype \
         php7-curl \
@@ -38,6 +39,8 @@ RUN --mount=type=cache,target=/var/cache/apk \
         php7-zip \
     && \
     cleanup.sh
+
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 COPY rootfs /
 

--- a/nginx/rootfs/etc/services.d/fpm/run
+++ b/nginx/rootfs/etc/services.d/fpm/run
@@ -1,4 +1,5 @@
+#!/bin/sh
 #!/usr/bin/execlineb -P
 # -*- mode: sh -*-
 # vi: set ft=sh:
-/usr/sbin/php-fpm7
+with-contenv /usr/sbin/php-fpm7

--- a/nginx/rootfs/etc/services.d/nginx/run
+++ b/nginx/rootfs/etc/services.d/nginx/run
@@ -1,4 +1,5 @@
+#!/bin/sh
 #!/usr/bin/execlineb -P
 # -*- mode: sh -*-
 # vi: set ft=sh:
-/usr/sbin/nginx
+with-contenv /usr/sbin/nginx


### PR DESCRIPTION
* Brings php module list in sync with ISLE, adding `php-libiconv` among others
* installs gnu-libiconv, which is necessary because the `musl` implementation of the C library on Alpine does not have gnu features
* Exposes environment variables to nginx and php-fpm upon startup, so that `LD_PRELOAD` is defined, and the external libiconv library can be loaded

## To test
Bethany already tested this PR.  For ops review, please check [this commit](https://github.com/jhu-idc/idc-isle-buildkit/pull/66/commits/b62585af43ebe5b0667e1c8644c25031103df239), changing the way that nginx and fpm backends are launched by s6.  I did this so that the environment variable `LD_PRELOAD` is set when each are initially executed.    The biggest change is that `sh` is used instead of `execlineb`.  `execlineb` claims to have security benefits that I don't fully understand.  Please verify that this PR is not creating a new security hole.