### PR TITLE
Restore dependency git repos

### DIFF
--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -134,7 +134,7 @@ function main {
   then
     COMPOSER_MEMORY_LIMIT=-1 composer install 
   else
-    COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-install=source
+    COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-install=auto
   fi
 
   if [ -z "${db_count}" ] || [ "${db_count}" -lt 1 ] ; then

--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -130,7 +130,12 @@ function main {
   $(installed_local) || db_count=$?
 
   # Install Composer modules if necessary.
-  COMPOSER_MEMORY_LIMIT=-1 composer install
+  if [ -n "${DRUPAL_INSTANCE}" ] && [ "${DRUPAL_INSTANCE}" != "dev" ] ;
+  then
+    COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-install=source
+  else
+    COMPOSER_MEMORY_LIMIT=-1 composer install
+  fi
 
   if [ -z "${db_count}" ] || [ "${db_count}" -lt 1 ] ; then
     printf "\n\nERROR: Drupal is not installed, no pre-existing state found\n\n"

--- a/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
+++ b/drupal/rootfs/etc/cont-init.d/99-custom-setup.sh
@@ -132,9 +132,9 @@ function main {
   # Install Composer modules if necessary.
   if [ -n "${DRUPAL_INSTANCE}" ] && [ "${DRUPAL_INSTANCE}" != "dev" ] ;
   then
-    COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-install=source
+    COMPOSER_MEMORY_LIMIT=-1 composer install 
   else
-    COMPOSER_MEMORY_LIMIT=-1 composer install
+    COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-install=source
   fi
 
   if [ -z "${db_count}" ] || [ "${db_count}" -lt 1 ] ; then


### PR DESCRIPTION
Local testing showed that using the `--prefer-install=auto` flag during a composer dependency install should download the full git repo of `dev-` dependencies, the same default behavior of Composer 1.x. This is only desirable in the development environment, though.

Trying this approach as a possible solution

