### PR TITLE
Make web console host/port configurable

### DIFF
--- a/activemq/README.md
+++ b/activemq/README.md
@@ -47,6 +47,9 @@ additional settings, volumes, ports, etc.
 | ACTIVEMQ_WEB_ADMIN_NAME     | /activemq/web/admin/name     | admin    | See [WebConsole]: jetty-realm.properties |
 | ACTIVEMQ_WEB_ADMIN_PASSWORD | /activemq/web/admin/password | password | See [WebConsole]: jetty-realm.properties |
 | ACTIVEMQ_WEB_ADMIN_ROLES    | /activemq/web/admin/roles    | admin    | See [WebConsole]: jetty-realm.properties |
+| ACTIVEMQ_WEB_HOST    | /activemq/web/host     | 127.0.0.1 | Host the admin console will bind to, use 0.0.0.0 for any |
+| ACTIVEMQ_WEB_PORT    | /activemq/web/iport    | 8161 | Admin console port |
+
 
 Additional users/groups/etc can be defined by adding more environment variables,
 following the above conventions:

--- a/activemq/rootfs/etc/confd/conf.d/jetty.xml.toml
+++ b/activemq/rootfs/etc/confd/conf.d/jetty.xml.toml
@@ -1,0 +1,7 @@
+[template]
+src = "jetty.xml.tmpl"
+dest = "/opt/activemq/conf/jetty.xml"
+uid = 100
+gid = 1000
+mode = "0640"
+keys = [ "/web/host", "/web/port" ]

--- a/activemq/rootfs/etc/confd/templates/jetty.xml.tmpl
+++ b/activemq/rootfs/etc/confd/templates/jetty.xml.tmpl
@@ -1,0 +1,185 @@
+
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more contributor
+        license agreements. See the NOTICE file distributed with this work for additional
+        information regarding copyright ownership. The ASF licenses this file to You under
+        the Apache License, Version 2.0 (the "License"); you may not use this file except in
+        compliance with the License. You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or
+        agreed to in writing, software distributed under the License is distributed on an
+        "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied. See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+    <!--
+        An embedded servlet engine for serving up the Admin consoles, REST and Ajax APIs and
+        some demos Include this file in your configuration to enable ActiveMQ web components
+        e.g. <import resource="jetty.xml"/>
+    -->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="securityLoginService" class="org.eclipse.jetty.security.HashLoginService">
+        <property name="name" value="ActiveMQRealm" />
+        <property name="config" value="${activemq.conf}/jetty-realm.properties" />
+    </bean>
+
+    <bean id="securityConstraint" class="org.eclipse.jetty.util.security.Constraint">
+        <property name="name" value="BASIC" />
+        <property name="roles" value="user,admin" />
+        <!-- set authenticate=false to disable login -->
+        <property name="authenticate" value="true" />
+    </bean>
+    <bean id="adminSecurityConstraint" class="org.eclipse.jetty.util.security.Constraint">
+        <property name="name" value="BASIC" />
+        <property name="roles" value="admin" />
+         <!-- set authenticate=false to disable login -->
+        <property name="authenticate" value="true" />
+    </bean>
+    <bean id="securityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
+        <property name="constraint" ref="securityConstraint" />
+        <property name="pathSpec" value="/*,/api/*,/admin/*,*.jsp" />
+    </bean>
+    <bean id="adminSecurityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
+        <property name="constraint" ref="adminSecurityConstraint" />
+        <property name="pathSpec" value="*.action" />
+    </bean>
+    
+    <bean id="rewriteHandler" class="org.eclipse.jetty.rewrite.handler.RewriteHandler">
+        <property name="rules">
+            <list>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                  <property name="pattern" value="*"/>
+                  <property name="name" value="X-FRAME-OPTIONS"/>
+                  <property name="value" value="SAMEORIGIN"/>
+                </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                  <property name="pattern" value="*"/>
+                  <property name="name" value="X-XSS-Protection"/>
+                  <property name="value" value="1; mode=block"/>
+                </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                  <property name="pattern" value="*"/>
+                  <property name="name" value="X-Content-Type-Options"/>
+                  <property name="value" value="nosniff"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+    
+	<bean id="secHandlerCollection" class="org.eclipse.jetty.server.handler.HandlerCollection">
+		<property name="handlers">
+			<list>
+   	            <ref bean="rewriteHandler"/>
+				<bean class="org.eclipse.jetty.webapp.WebAppContext">
+					<property name="contextPath" value="/admin" />
+					<property name="resourceBase" value="${activemq.home}/webapps/admin" />
+					<property name="logUrlOnStart" value="true" />
+				</bean>
+				<bean class="org.eclipse.jetty.webapp.WebAppContext">
+					<property name="contextPath" value="/api" />
+					<property name="resourceBase" value="${activemq.home}/webapps/api" />
+					<property name="logUrlOnStart" value="true" />
+				</bean>
+				<bean class="org.eclipse.jetty.server.handler.ResourceHandler">
+					<property name="directoriesListed" value="false" />
+					<property name="welcomeFiles">
+						<list>
+							<value>index.html</value>
+						</list>
+					</property>
+					<property name="resourceBase" value="${activemq.home}/webapps/" />
+				</bean>
+				<bean id="defaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler">
+					<property name="serveIcon" value="false" />
+				</bean>
+			</list>
+		</property>
+	</bean>    
+    <bean id="securityHandler" class="org.eclipse.jetty.security.ConstraintSecurityHandler">
+        <property name="loginService" ref="securityLoginService" />
+        <property name="authenticator">
+            <bean class="org.eclipse.jetty.security.authentication.BasicAuthenticator" />
+        </property>
+        <property name="constraintMappings">
+            <list>
+                <ref bean="adminSecurityConstraintMapping" />
+                <ref bean="securityConstraintMapping" />
+            </list>
+        </property>
+        <property name="handler" ref="secHandlerCollection" />
+    </bean>
+
+    <bean id="contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
+    </bean>
+
+    <bean id="jettyPort" class="org.apache.activemq.web.WebConsolePort" init-method="start">
+             <!-- the default port number for the web console -->
+        <property name="host" value="{{ getv "/web/host" "127.0.0.1" }}"/>
+        <property name="port" value="{{ getv "/web/port" "8161" }}"/>
+    </bean>
+
+    <bean id="Server" depends-on="jettyPort" class="org.eclipse.jetty.server.Server"
+        destroy-method="stop">
+
+        <property name="handler">
+            <bean id="handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+                <property name="handlers">
+                    <list>
+                        <ref bean="contexts" />
+                        <ref bean="securityHandler" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+
+    </bean>
+
+    <bean id="invokeConnectors" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    	<property name="targetObject" ref="Server" />
+    	<property name="targetMethod" value="setConnectors" />
+    	<property name="arguments">
+    	<list>
+           	<bean id="Connector" class="org.eclipse.jetty.server.ServerConnector">
+           		<constructor-arg ref="Server" />
+                    <!-- see the jettyPort bean -->
+                   <property name="host" value="#{systemProperties['jetty.host']}" />
+                   <property name="port" value="#{systemProperties['jetty.port']}" />
+               </bean>
+                <!--
+                    Enable this connector if you wish to use https with web console
+                -->
+                <!-- bean id="SecureConnector" class="org.eclipse.jetty.server.ServerConnector">
+					<constructor-arg ref="Server" />
+					<constructor-arg>
+						<bean id="handlers" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+						
+							<property name="keyStorePath" value="${activemq.conf}/broker.ks" />
+							<property name="keyStorePassword" value="password" />
+						</bean>
+					</constructor-arg>
+					<property name="port" value="8162" />
+				</bean -->
+            </list>
+    	</property>
+    </bean>
+
+	<bean id="configureJetty" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+		<property name="staticMethod" value="org.apache.activemq.web.config.JspConfigurer.configureJetty" />
+		<property name="arguments">
+			<list>
+				<ref bean="Server" />
+				<ref bean="secHandlerCollection" />
+			</list>
+		</property>
+	</bean>
+    
+    <bean id="invokeStart" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" 
+    	depends-on="configureJetty, invokeConnectors">
+    	<property name="targetObject" ref="Server" />
+    	<property name="targetMethod" value="start" />  	
+    </bean>
+    
+    
+</beans>


### PR DESCRIPTION
Adds configuration to bind the activemq web console to different devices (e.g. `0.0.0.0` for all).

By default, the activemq web console only binds to localhost, making it impossible in the dev environment to point a browser at the console. 

Adds env vars:
| ACTIVEMQ_WEB_HOST`    | /activemq/web/host     | 127.0.0.1 | Host the admin console will bind to, use 0.0.0.0 for any |
| ACTIVEMQ_WEB_PORT    | /activemq/web/iport    | 8161 | Admin console port |