### PR TITLE
Update alpine to 3.14.0

### DIFF
--- a/abuild/Dockerfile
+++ b/abuild/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:experimental
 FROM alpine:3.13.7
 
+
 RUN --mount=type=cache,target=/var/cache/apk \ 
     --mount=type=cache,target=/etc/cache/apk \
     ln -s /var/cache/apk /etc/apk/cache && \
@@ -10,3 +11,4 @@ RUN --mount=type=cache,target=/var/cache/apk \
     && \
     adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder && \
     echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+

--- a/abuild/Dockerfile
+++ b/abuild/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine:3.13.7
+FROM alpine:3.14
 
 
 RUN --mount=type=cache,target=/var/cache/apk \ 
@@ -8,6 +8,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
     apk add --update \
         alpine-sdk \
         coreutils \
+        sudo \
     && \
     adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder && \
     echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,6 +19,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
         netcat-openbsd \
         openssl \
         postgresql-client \
+        sudo \
         wget \
     && \
     S6_VERSION="1.22.1.0" && \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine:3.13.7
+FROM alpine:3.14
 
 COPY build/download.sh /usr/local/bin
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,7 +19,6 @@ RUN --mount=type=cache,target=/var/cache/apk \
         netcat-openbsd \
         openssl \
         postgresql-client \
-        sudo \
         wget \
     && \
     S6_VERSION="1.22.1.0" && \

--- a/crayfish/rootfs/etc/confd/conf.d/default.conf.toml
+++ b/crayfish/rootfs/etc/confd/conf.d/default.conf.toml
@@ -1,6 +1,6 @@
 [template]
 src = "default.conf.tmpl"
-dest = "/etc/nginx/conf.d/default.conf"
+dest = "/etc/nginx/http.d/default.conf"
 uid = 100
 gid = 101
 mode = "0644"

--- a/crayfits/rootfs/etc/confd/conf.d/default.conf.toml
+++ b/crayfits/rootfs/etc/confd/conf.d/default.conf.toml
@@ -1,6 +1,6 @@
 [template]
 src = "default.conf.tmpl"
-dest = "/etc/nginx/conf.d/default.conf"
+dest = "/etc/nginx/http.d/default.conf"
 uid = 100
 gid = 101
 mode = "0644"

--- a/drupal/rootfs/etc/confd/conf.d/default.conf.toml
+++ b/drupal/rootfs/etc/confd/conf.d/default.conf.toml
@@ -1,6 +1,6 @@
 [template]
 src = "nginx_default.conf.tmpl"
-dest = "/etc/nginx/conf.d/default.conf"
+dest = "/etc/nginx/http.d/default.conf"
 uid = 0
 gid = 0
 mode = "0444"

--- a/matomo/rootfs/etc/confd/conf.d/default.conf.toml
+++ b/matomo/rootfs/etc/confd/conf.d/default.conf.toml
@@ -1,6 +1,6 @@
 [template]
 src = "default.conf.tmpl"
-dest = "/etc/nginx/conf.d/default.conf"
+dest = "/etc/nginx/http.d/default.conf"
 uid = 100
 gid = 101
 mode = "0644"

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -41,6 +41,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
     composer self-update --2 && \
     cleanup.sh
 
+RUN apk add gnu-libiconv=1.15-r3 --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ --allow-untrusted
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 COPY rootfs /

--- a/nginx/rootfs/etc/confd/templates/nginx.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/nginx.conf.tmpl
@@ -81,5 +81,5 @@ http {
         access_log /dev/stdout main;
 
         # Includes virtual hosts configs.
-        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/http.d/*.conf;
 }

--- a/tomcat/rootfs/etc/confd/conf.d/default.conf.toml
+++ b/tomcat/rootfs/etc/confd/conf.d/default.conf.toml
@@ -1,6 +1,6 @@
 [template]
 src = "default.conf.tmpl"
-dest = "/etc/nginx/conf.d/default.conf"
+dest = "/etc/nginx/http.d/default.conf"
 uid = 100
 gid = 101
 mode = "0644"


### PR DESCRIPTION
This upgrades the alpine base image to 3.14.0. In the update, the references to the nginx config directory needed to be changed to the new location. We also needed to manually add an apk that provides the `preloadable_libiconv.so` for `php-iconv` 