### PR TITLE
ActiveMQ improvements: fix for STOMP heartbeat, redelivery policy, and configuration for DLQ

### DIFF
--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -1,23 +1,49 @@
 # syntax=docker/dockerfile:experimental
+FROM local/java:latest as builder
+
+COPY rootfs/heartbeat-interval.patch /
+
+RUN ACTIVEMQ_VERSION="5.16.3" && \
+    ACTIVEMQ_GIT_REPO="https://github.com/apache/activemq" && \
+    ACTIVEMQ_GIT_TAG="activemq-${ACTIVEMQ_VERSION}" && \
+    mkdir -p /opt/builds && \
+    cd /opt/builds && \
+    git clone --depth 1 -b ${ACTIVEMQ_GIT_TAG} ${ACTIVEMQ_GIT_REPO} && \
+    cd activemq
+
+WORKDIR /opt/builds/activemq
+
+# patch activemq-stomp
+RUN patch -p1 < /heartbeat-interval.patch
+
+# build activemq-stomp so the artifact is in the local maven repository.  build activemq-web-console so the classes are
+# available in activemq-web-console/target for the assembly to pick up.  the remaining artifacts will be downloaded from
+# maven central during assembly
+RUN cd activemq-stomp && \
+    mvn install -DskipTests && \
+    cd ../activemq-web-console && \
+    mvn package -DskipTests
+
+# assemble the binary; will use the locally built activemq-stomp artifact, and pick up activemq-web-console/target.
+RUN cd /opt/builds/activemq/assembly && \
+    mvn assembly:single@unix-bin -DskipTests
+
 FROM local/java:latest
 
-RUN --mount=id=downloads,type=cache,target=/opt/downloads \
-    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
-    ACTIVEMQ_VERSION="5.16.3" && \
-    ACTIVEMQ_FILE="apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz" && \
-    ACTIVEMQ_URL="https://archive.apache.org/dist/activemq/${ACTIVEMQ_VERSION}/${ACTIVEMQ_FILE}" && \
-    ACTIVEMQ_FILE_SHA256="1846da2985ec64253ecc41a54f1477731eb4750fe840a9dd9fdfee88e5c94252" && \
-    ACTIVEMQ_SIG_SHA256="ba60843a12fd74424d4ec62752e888b0b58fecd53c63f1497f8ea0cb6ef5d457" && \
-    download.sh --url "${ACTIVEMQ_URL}" --sha256 "${ACTIVEMQ_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
-    download.sh --url "${ACTIVEMQ_URL}.asc" --sha256 "${ACTIVEMQ_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
-    install-apache-service.sh \
-        --name activemq \
-        --key "1AA8CF92D409A73393D0B736BFF2EE42C8282E76" \
-        --file "${DOWNLOAD_CACHE_DIRECTORY}/${ACTIVEMQ_FILE}" \
-        examples webapps-demo docs
+RUN mkdir -p /opt/downloads
+
+COPY --from=builder /opt/builds/activemq/assembly/target/apache-activemq-5.16.3-bin.tar.gz /opt/downloads
+
+# install-apache-service.sh modified to not require a signed artifact
+RUN install-apache-service.sh \
+      --name activemq \
+      --file /opt/downloads/apache-activemq-5.16.3-bin.tar.gz \
+    examples webapps-demo docs
 
 WORKDIR /opt/activemq
 
 EXPOSE 61616 5672 61613 1883 61614 8161
 
 COPY rootfs /
+
+RUN chown -R activemq:activemq /opt/activemq

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -49,6 +49,12 @@ additional settings, volumes, ports, etc.
 | ACTIVEMQ_WEB_ADMIN_ROLES    | /activemq/web/admin/roles    | admin    | See [WebConsole]: jetty-realm.properties |
 | ACTIVEMQ_WEB_HOST    | /activemq/web/host     | 127.0.0.1 | Host the admin console will bind to, use 0.0.0.0 for any |
 | ACTIVEMQ_WEB_PORT    | /activemq/web/iport    | 8161 | Admin console port |
+| ACTIVEMQ_REDELIVERY_MAX_ATTEMPTS | /activemq/redelivery/max/attempts | 1 | Total number of attempts to redeliver a message before routing it to the DLQ |
+| ACTIVEMQ_REDELIVERY_INITIAL_DELAY_MS | /activemq/redelivery/initial/delay/ms | 60000 | Delay before attempting the first redelivery |
+| ACTIVEMQ_REDELIVERY_DELAY_MS | /activemq/redelivery/delay/ms | 60000 | Delay between subsequent redelivery attempts |
+| ACTIVEMQ_DLQ_EXPIRATION_MS | /activemq/dlq/expiration/ms | 604800000 | Lifetime of a message in the DLQ, after which it is deleted |
+| ACTIVEMQ_DLQ_PROCESS_EXPIRED | /activemq/dlq/process/expired | true | Whether undelivered, expired messages are **routed to** the DLQ.  If 'true', undelivered, expired messages will be sent to the DLQ and kept for ${ACTIVEMQ_DLQ_EXPIRATION_MS} milliseconds before being deleted. If 'false', undelivered, expired messages will be deleted, bypassing the DLQ.  | 
+| ACTIVEMQ_DLQ_PROCESS_NON_PERSISTENT | /activemq/dlq/process/non/persistent | true | Whether undelivered, non-persistent are **routed to** the DLQ.  If 'true', undeliverable, non-persistent messages will be routed to the DLQ and kept for ${ACTIVEMQ_DLQ_EXPIRATION_MS} milliseconds before being deleted.  If 'false', undeliverable, non-persistent messages will be deleted. |
 
 
 Additional users/groups/etc can be defined by adding more environment variables,

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -55,6 +55,9 @@ additional settings, volumes, ports, etc.
 | ACTIVEMQ_DLQ_EXPIRATION_MS | /activemq/dlq/expiration/ms | 604800000 | Lifetime of a message in the DLQ, after which it is deleted |
 | ACTIVEMQ_DLQ_PROCESS_EXPIRED | /activemq/dlq/process/expired | true | Whether undelivered, expired messages are **routed to** the DLQ.  If 'true', undelivered, expired messages will be sent to the DLQ and kept for ${ACTIVEMQ_DLQ_EXPIRATION_MS} milliseconds before being deleted. If 'false', undelivered, expired messages will be deleted, bypassing the DLQ.  | 
 | ACTIVEMQ_DLQ_PROCESS_NON_PERSISTENT | /activemq/dlq/process/non/persistent | true | Whether undelivered, non-persistent are **routed to** the DLQ.  If 'true', undeliverable, non-persistent messages will be routed to the DLQ and kept for ${ACTIVEMQ_DLQ_EXPIRATION_MS} milliseconds before being deleted.  If 'false', undeliverable, non-persistent messages will be deleted. |
+| ACTIVEMQ_SYSTEM_USAGE_JVM_HEAP_PERCENTAGE | /system/usage/jvm/heap/percent | 70 | |
+| ACTIVEMQ_SYSTEM_USAGE_DURABLE_STORAGE_LIMIT | /system/usage/durable/storage/limit | `100 gb` | |
+| ACTIVEMQ_SYSTEM_USAGE_TEMP_STORAGE_LIMIT | /system/usage/temp/storage/limit | `18 gb` | |
 
 
 Additional users/groups/etc can be defined by adding more environment variables,

--- a/activemq/rootfs/etc/confd/conf.d/activemq.xml.toml
+++ b/activemq/rootfs/etc/confd/conf.d/activemq.xml.toml
@@ -4,3 +4,4 @@ dest = "/opt/activemq/conf/activemq.xml"
 uid = 100
 gid = 1000
 mode = "0640"
+keys = [ "/dlq", "/redelivery" ]

--- a/activemq/rootfs/etc/confd/conf.d/activemq.xml.toml
+++ b/activemq/rootfs/etc/confd/conf.d/activemq.xml.toml
@@ -4,4 +4,4 @@ dest = "/opt/activemq/conf/activemq.xml"
 uid = 100
 gid = 1000
 mode = "0640"
-keys = [ "/dlq", "/redelivery" ]
+keys = [ "/dlq", "/redelivery", "/system" ]

--- a/activemq/rootfs/etc/confd/conf.d/activemq.xml.toml
+++ b/activemq/rootfs/etc/confd/conf.d/activemq.xml.toml
@@ -1,0 +1,6 @@
+[template]
+src = "activemq.xml.tmpl"
+dest = "/opt/activemq/conf/activemq.xml"
+uid = 100
+gid = 1000
+mode = "0640"

--- a/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
+++ b/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
@@ -1,0 +1,136 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- START SNIPPET: example -->
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+   <!-- Allows accessing the server log -->
+    <bean id="logQuery" class="io.fabric8.insight.log.log4j.Log4jLogQuery"
+          lazy-init="false" scope="singleton"
+          init-method="start" destroy-method="stop">
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" >
+                    <!-- The constantPendingMessageLimitStrategy is used to prevent
+                         slow topic consumers to block producers and affect other consumers
+                         by limiting the number of messages that are retained
+                         For more information, see:
+
+                         http://activemq.apache.org/slow-consumer-handling.html
+
+                    -->
+                  <pendingMessageLimitStrategy>
+                    <constantPendingMessageLimitStrategy limit="1000"/>
+                  </pendingMessageLimitStrategy>
+                </policyEntry>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+
+
+          <!--
+            The systemUsage controls the maximum amount of space the broker will
+            use before disabling caching and/or slowing down producers. For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+          -->
+          <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70" />
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+        </transportConnectors>
+
+        <!-- destroy the spring context on shutdown to stop jetty -->
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook" />
+        </shutdownHooks>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+        The web consoles requires by default login, you can disable this in the jetty.xml file
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>
+<!-- END SNIPPET: example -->

--- a/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
+++ b/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
@@ -46,9 +46,9 @@
                     <redeliveryPolicyMap>
                         <defaultEntry>
                             <!-- the policy for all destinations -->
-                            <redeliveryPolicy maximumRedeliveries="5"
-                                              initialRedeliveryDelay="5000"
-                                              redeliveryDelay="60000"/>
+                            <redeliveryPolicy maximumRedeliveries="{{ getv "/redelivery/max/attempts" "1" }}"
+                                              initialRedeliveryDelay="{{ getv "/redelivery/initial/delay/ms" "60000" }}"
+                                              redeliveryDelay="{{ getv "/redelivery/delay/ms" "60000" }}"/>
                         </defaultEntry>
                     </redeliveryPolicyMap>
                 </redeliveryPolicyMap>
@@ -74,7 +74,7 @@
                 <policyEntry queue=">">
                   <deadLetterStrategy>
                       <!-- ActiveMQ.DLQ will keep persistent, undelivered messages for one week -->
-                      <sharedDeadLetterStrategy expiration="604800000" processExpired="true" processNonPersistent="true" />
+                      <sharedDeadLetterStrategy expiration="{{ getv "/dlq/expiration/ms" "604800000" }}" processExpired="{{ getv "/dlq/process/expired" "true" }}" processNonPersistent="{{ getv "/dlq/process/non/persistent" "true" }}" />
                   </deadLetterStrategy>
                 </policyEntry>
               </policyEntries>

--- a/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
+++ b/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
@@ -74,7 +74,7 @@
                 <policyEntry queue=">">
                   <deadLetterStrategy>
                       <!-- ActiveMQ.DLQ will keep persistent, undelivered messages for one week -->
-                      <sharedDeadLetterStrategy expiration="604800000" processExpired="true" />
+                      <sharedDeadLetterStrategy expiration="604800000" processExpired="true" processNonPersistent="true" />
                   </deadLetterStrategy>
                 </policyEntry>
               </policyEntries>

--- a/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
+++ b/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
@@ -113,13 +113,13 @@
           <systemUsage>
             <systemUsage>
                 <memoryUsage>
-                    <memoryUsage percentOfJvmHeap="70" />
+                    <memoryUsage percentOfJvmHeap="{{ getv "/system/usage/jvm/heap/percent" "70" }}" />
                 </memoryUsage>
                 <storeUsage>
-                    <storeUsage limit="100 gb"/>
+                    <storeUsage limit="{{ getv "/system/usage/durable/storage/limit" "100 gb"}}" />
                 </storeUsage>
                 <tempUsage>
-                    <tempUsage limit="50 gb"/>
+                    <tempUsage limit="{{ getv "/system/usage/temp/storage/limit" "18 gb"}}" />
                 </tempUsage>
             </systemUsage>
         </systemUsage>

--- a/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
+++ b/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
@@ -37,7 +37,23 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}" schedulerSupport="true">
+
+        <plugins>
+            <redeliveryPlugin fallbackToDeadLetter="true"
+                              sendToDlqIfMaxRetriesExceeded="true">
+                <redeliveryPolicyMap>
+                    <redeliveryPolicyMap>
+                        <defaultEntry>
+                            <!-- the policy for all destinations -->
+                            <redeliveryPolicy maximumRedeliveries="5"
+                                              initialRedeliveryDelay="5000"
+                                              redeliveryDelay="60000"/>
+                        </defaultEntry>
+                    </redeliveryPolicyMap>
+                </redeliveryPolicyMap>
+            </redeliveryPlugin>
+        </plugins>
 
         <destinationPolicy>
             <policyMap>

--- a/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
+++ b/activemq/rootfs/etc/confd/templates/activemq.xml.tmpl
@@ -55,6 +55,12 @@
                     <constantPendingMessageLimitStrategy limit="1000"/>
                   </pendingMessageLimitStrategy>
                 </policyEntry>
+                <policyEntry queue=">">
+                  <deadLetterStrategy>
+                      <!-- ActiveMQ.DLQ will keep persistent, undelivered messages for one week -->
+                      <sharedDeadLetterStrategy expiration="604800000" processExpired="true" />
+                  </deadLetterStrategy>
+                </policyEntry>
               </policyEntries>
             </policyMap>
         </destinationPolicy>

--- a/activemq/rootfs/heartbeat-interval.patch
+++ b/activemq/rootfs/heartbeat-interval.patch
@@ -1,0 +1,89 @@
+diff --git a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/ProtocolConverter.java b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/ProtocolConverter.java
+index b25860bf6..98aa60cee 100644
+--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/ProtocolConverter.java
++++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/ProtocolConverter.java
+@@ -971,8 +971,8 @@ public class ProtocolConverter {
+             try {
+                 StompInactivityMonitor monitor = this.stompTransport.getInactivityMonitor();
+                 monitor.setReadCheckTime((long) (hbReadInterval * hbGracePeriodMultiplier));
+-                monitor.setInitialDelayTime(Math.min(hbReadInterval, hbWriteInterval));
+-                monitor.setWriteCheckTime(hbWriteInterval);
++                monitor.setInitialDelayTime(Math.min(hbReadInterval, workaroundHbWriteInterval(hbWriteInterval)));
++                monitor.setWriteCheckTime(workaroundHbWriteInterval(hbWriteInterval));
+                 monitor.startMonitoring();
+             } catch(Exception ex) {
+                 hbReadInterval = 0;
+@@ -985,6 +985,19 @@ public class ProtocolConverter {
+         }
+     }
+
++    // The InactivityMonitor may send heartbeats half as often as requested, so
++    // work around that by asking for twice as often.
++    //
++    // The InactivityMonitor behaves that way because it checks periodically
++    // whether a write has been sent since the last check:
++    // |-------------------|-------------------|
++    //        ^                                ^
++    //        |                                |
++    //   activity here          means no heartbeat until here
++    protected static long workaroundHbWriteInterval(long hbWriteInterval) {
++        return hbWriteInterval / 2;
++    }
++
+     protected void sendReceipt(StompFrame command) {
+         final String receiptId = command.getHeaders().get(Stomp.Headers.RECEIPT_REQUESTED);
+         if (receiptId != null) {
+diff --git a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompInactivityMonitorTest.java b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompInactivityMonitorTest.java
+index 20f4ed9c0..76bc17b1d 100644
+--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompInactivityMonitorTest.java
++++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompInactivityMonitorTest.java
+@@ -91,6 +91,49 @@ public class StompInactivityMonitorTest extends StompTestSupport {
+         assertTrue(response.startsWith("RECEIPT"));
+     }
+
++    // For JIRA ticket AMQ-4710
++    //
++    // Sometimes STOMP heartbeats were sent too infrequently. This test checks
++    // for that. We have to do that with a low-level Socket connection because
++    // the heartbeats don't give rise to frames.
++    @Test(timeout = 2000)
++    public void testWriteHeartbeat() throws Exception {
++        Socket socket = createSocket();
++
++        String connectFrame = "STOMP\n" +
++            "login:system\n" +
++            "passcode:manager\n" +
++            "accept-version:1.1\n" +
++            "heart-beat:0,100\n" +
++            "host:localhost\n" +
++            "\n" + Stomp.NULL;
++
++        byte[] buffer = new byte[4096];
++        socket.getOutputStream().write(connectFrame.getBytes());
++        long read = socket.getInputStream().read(buffer);
++        LOG.info("initial read: " + new String(buffer, 0, (int)read));
++        // Sometimes we read the keepalive before the CONNECTED response. There
++        // must be a race somewhere. If that happens, just try to read the
++        // CONNECTED frame again.
++        if (read == 1) {
++            read = socket.getInputStream().read(buffer);
++            LOG.info("initial retry read: " + new String(buffer, 0, (int)read));
++        }
++
++        // Wait for a few heartbeats.
++        for (int i = 0; i < 4; i += 1) {
++            long startTime = System.currentTimeMillis();
++            read = socket.getInputStream().read(buffer);
++            long endTime = System.currentTimeMillis();
++            LOG.info("heartbeat read: " + new String(buffer, 0, (int)read));
++            long delay = endTime - startTime;
++            assertTrue("Should have received a keepalive newline", read >= 1);
++            assertTrue("Should have received a keepalive newline", buffer[0] == '\n');
++            assertTrue("Should have waited a reasonable length of time for keepalive, not " + delay + "ms",
++                    delay < 140);
++        }
++    }
++
+     @Override
+     protected boolean isUseTcpConnector() {
+         return !transportScheme.contains("nio") && !transportScheme.contains("ssl");

--- a/activemq/rootfs/opt/activemq/conf/log4j.properties
+++ b/activemq/rootfs/opt/activemq/conf/log4j.properties
@@ -1,0 +1,92 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+#
+# This file controls most of the logging in ActiveMQ which is mainly based around
+# the commons logging API.
+#
+log4j.rootLogger=INFO, console, logfile
+log4j.logger.org.apache.activemq.spring=WARN
+log4j.logger.org.apache.activemq.web.handler=WARN
+log4j.logger.org.springframework=WARN
+log4j.logger.org.apache.xbean=WARN
+log4j.logger.org.apache.camel=INFO
+log4j.logger.org.eclipse.jetty=WARN
+
+# When debugging or reporting problems to the ActiveMQ team,
+# comment out the above lines and uncomment the next.
+
+#log4j.rootLogger=DEBUG, logfile, console
+
+# Or for more fine grained debug logging uncomment one of these
+#log4j.logger.org.apache.activemq=DEBUG
+#log4j.logger.org.apache.camel=DEBUG
+#log4j.logger.org.apache.activemq.store=INFO
+# STOMP logging
+#log4j.logger.org.apache.activemq.transport.stomp=DEBUG
+
+# Console appender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%5p | %m%n
+log4j.appender.console.threshold=INFO
+
+# File appender
+log4j.appender.logfile=org.apache.log4j.RollingFileAppender
+log4j.appender.logfile.file=${activemq.data}/activemq.log
+log4j.appender.logfile.maxFileSize=1024KB
+log4j.appender.logfile.maxBackupIndex=5
+log4j.appender.logfile.append=true
+log4j.appender.logfile.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.logfile.layout.ConversionPattern=%d | %-5p | %m | %c | %t%n%throwable{full}
+
+# you can control the rendering of exception in the ConversionPattern
+# by default, we display the full stack trace
+# if you want to display short form of the exception, you can use
+#
+# log4j.appender.logfile.layout.ConversionPattern=%d | %-5p | %m | %c | %t%n%throwable{short}
+#
+# a classic issue with filebeat/logstash is about multiline exception. The following pattern
+# allows to work smoothly with filebeat/logstash
+#
+# log4j.appender.logfile.layour.ConversionPattern=%d | %-5p | %m | %c | %t%n%replace(%throwable){\n}{ }
+#
+
+# use some of the following patterns to see MDC logging data
+#
+# %X{activemq.broker}
+# %X{activemq.connector}
+# %X{activemq.destination}
+#
+# e.g.
+#
+# log4j.appender.logfile.layout.ConversionPattern=%d | %-20.20X{activemq.connector} | %-5p | %m | %c | %t%n
+
+###########
+# Audit log
+###########
+
+log4j.additivity.org.apache.activemq.audit=false
+log4j.logger.org.apache.activemq.audit=INFO, audit
+
+log4j.appender.audit=org.apache.log4j.RollingFileAppender
+log4j.appender.audit.file=${activemq.data}/audit.log
+log4j.appender.audit.maxFileSize=1024KB
+log4j.appender.audit.maxBackupIndex=5
+log4j.appender.audit.append=true
+log4j.appender.audit.layout=org.apache.log4j.PatternLayout
+log4j.appender.audit.layout.ConversionPattern=%-5p | %m | %t%n

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -7,6 +7,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
     apk-install.sh \
         openjdk8 \
         maven \
+        patch \
     && \
     cleanup.sh
 

--- a/java/rootfs/usr/local/bin/install-apache-service.sh
+++ b/java/rootfs/usr/local/bin/install-apache-service.sh
@@ -75,8 +75,8 @@ function cmdline() {
         esac
     done
 
-    if [[ -z $NAME || -z $KEY || -z $FILE ]]; then
-        echo "Missing one or more required options: --name --key --file"
+    if [[ -z $NAME || -z $FILE ]]; then
+        echo "Missing one or more required options: --name --file"
         exit 1
     fi
 


### PR DESCRIPTION
This PR updates the ActiveMQ configuration and includes a fix for a [long-standing STOMP heartbeat interval bug](https://issues.apache.org/jira/browse/AMQ-4710) (making it impossible for STOMP clients to stay reliably connected with an ActiveMQ broker).

### Build changes
* Applies a patch for [AMQ-4710](https://issues.apache.org/jira/browse/AMQ-4710)
* Builds ActiveMQ locally (so that our patch is included)

### Configuration changes
* configures a dead letter queue that expires messages after one week.
* attempts to re-send an undeliverable message 1 time, waiting one minute before making a second attempt
* includes the default `log4j.properties` file which can be tweaked at image build time to provide debugging information

### New ENV vars (see updated README)
- `ACTIVEMQ_REDELIVERY_MAX_ATTEMPTS`, default `1`
- `ACTIVEMQ_REDELIVERY_INITIAL_DELAY_MS`, default `60000`
- `ACTIVEMQ_REDELIVERY_DELAY_MS` , default `60000`
- `ACTIVEMQ_DLQ_EXPIRATION_MS`, default `604800000`
- `ACTIVEMQ_DLQ_PROCESS_EXPIRED`, default `true`
- `ACTIVEMQ_DLQ_PROCESS_NON_PERSISTENT`, default `true`
- `ACTIVEMQ_SYSTEM_USAGE_JVM_HEAP_PERCENTAGE`, default `70`
- `ACTIVEMQ_SYSTEM_USAGE_DURABLE_STORAGE_LIMIT`, default `100 gb`
- `ACTIVEMQ_SYSTEM_USAGE_TEMP_STORAGE_LIMIT` default `18 gb`
