### PR TITLE
Single change version: Updates crayfish repo and commit hash

### DIFF
--- a/crayfish/Dockerfile
+++ b/crayfish/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:experimental
 FROM local/nginx:latest
 
-ARG COMMIT=44eaba6613cf699594d707b13e124be73e85a996
+ARG COMMIT=df49600032ee785d00184da0da0d4baf901c3710
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     git-clone-cached.sh \
-        --url https://github.com/Islandora/Crayfish.git \
+        --url https://github.com/jhu-idc/Crayfish.git \
         --cache-dir "${DOWNLOAD_CACHE_DIRECTORY}" \
         --commit "${COMMIT}" \
         --worktree /var/www/crayfish && \


### PR DESCRIPTION
There are some changes in the Houdini micro service to help cleanup imagemagic tmp files if left behind - this PR pulls in those changes.

This also:

Switches us to referencing our own fork of crayfish in the crayfish docker file

This is a simpler version of #90 