### PR TITLE
Update Houdini's Imagemagic policy.xml file

### DIFF
--- a/houdini/rootfs/etc/confd/templates/policy.xml.tmpl
+++ b/houdini/rootfs/etc/confd/templates/policy.xml.tmpl
@@ -4,7 +4,7 @@
   <policy domain="resource" name="memory" value="2GiB"/>
   <policy domain="resource" name="list-length" value="32"/>
   <policy domain="resource" name="map" value="4GiB"/>
-  <policy domain="resource" name="disk" value="2GiB"/>
+  <policy domain="resource" name="disk" value="10GiB"/>
   <policy domain="resource" name="file" value="768"/>
   <policy domain="resource" name="thread" value="2"/>
   <policy domain="resource" name="time" value="7200"/>
@@ -18,6 +18,7 @@
   <policy domain="coder" rights="none" pattern="WIN" />
   <policy domain="coder" rights="none" pattern="PLT" />
   <policy domain="path" rights="none" pattern="@*" />
+  <policy domain="cache" name="synchronize" value="True"/>
   <!-- disable ghostscript format types -->
   <policy domain="coder" rights="read|write" pattern="PS" />
   <policy domain="coder" rights="read|write" pattern="EPS" />


### PR DESCRIPTION
This makes a few tweaks to the Imagemagic policy.xml file. 

Based on the descriptions in ImageMagicks [Architecture writeup](https://imagemagick.org/script/architecture.php), I propose these changes below:

- Change`disk` to `10GiB`. Some suggest `unlimited` but that makes me nervous. Honestly, 10 makes me nervous, too, but I do think we should raise this somewhat. If this limit is hit, then the process stops, so I wonder if that's why we stopped before, as the files left behind are all about the same size. 
This is output from the houdini container's tmp file from our test cloud server setup:
```
bash-5.0# ls /tmp/ -lh
total 6G
-rw-------    1 nginx    nginx       1.4G Dec  6 20:33 magick-PURM5dZzxSr1wXYuTGrVq0xjJGGhjJDe
-rw-------    1 nginx    nginx       1.4G Dec  6 20:31 magick-fLKslbEtDwDbMMjRiqKACrh8eTPIklcD
-rw-------    1 nginx    nginx       1.4G Dec  6 20:32 magick-hUP7nuVA04WR66zLQei3H5zTQCcECNKO
-rw-------    1 nginx    nginx       1.4G Dec  6 20:30 magick-lCBNjyTogqEBMGwUUjGM7sA2PGeKjmFG
bash-5.0# 
```

 - Add in `<policy domain="cache" name="synchronize" value="True"/>`, which, in theory will make sure all things are flushed to disk, which will ensure that it will better handle when the system runs out of disk space. [ ImageMagick Doc ](https://imagemagick.org/script/security-policy.php)
```With memory-mapping, we get an increase in performance (up to 5x), however, there remains a possibility that as the disk file is populated, it may run out of free space. The OS then throws a SIGBUS signal which prevents ImageMagick from continuing. To prevent a SIGBUS, use this security policy:

<policy domain="cache" name="synchronize" value="True"/>
Set to True to ensure all image data is fully flushed and synchronized to disk. There is a performance penalty, however, the benefits include ensuring a valid image file in the event of a system crash and early reporting if there is not enough disk space for the image pixel cache.
```