### PR TITLE
Updates cantaloupe tomcat directory permissions to lock them down some

### DIFF
--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -23,6 +23,13 @@ RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     rm -fr "/tmp/${CANTALOUPE_UNPACKED}" && \
     mkdir /data && \
     chown tomcat:tomcat /data && \
-    chown -R tomcat:tomcat /opt/tomcat
+    chown -R root:tomcat /opt/tomcat && \
+    chown -R tomcat:tomcat /opt/tomcat/conf && \
+    chown -R tomcat:tomcat /opt/tomcat/logs && \
+    chmod -R g+r /opt/tomcat && \
+    chmod -R g+rw /opt/tomcat/logs && \
+    chmod -R g+rw /opt/tomcat/temp && \
+    chmod -R g+rw /opt/tomcat/work && \
+    chmod -R g+rw /opt/tomcat/webapps
 
 COPY rootfs /


### PR DESCRIPTION
This moves away from complete access by the tomcat user. 

I used recommendations from the [ticket](https://github.com/jhu-idc/iDC-general/issues/455) and [tomcat's page](https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Non-Tomcat_settings) as a guide. 

