### PR TITLE
Changes gradle to use mavenCentral() for dependencies.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        gradlePluginPortal()
+        mavenCentral()
         maven {
             url = uri("https://plugins.gradle.org/m2/")
         }


### PR DESCRIPTION
This PR is a test to see if it fixes the jcenter error that's being seeing on builds. 

It switches us to using maven central specifically to prevent a failure for when jcenter.bintray goes down or disappears altogether.  

Right now jcenter.bintray is down, but it's read only anyways and probably better to switch to maven central. 

https://testfairy.com/blog/jcenter-and-bintray-is-shutting-down-what-to-do/#:~:text=Bintray%20services%20will%20no%20longer%20be%20available.&text=JCenter%20will%20no%20longer%20be,will%20no%20longer%20be%20allowed.

and

https://blog.gradle.org/jcenter-shutdown

